### PR TITLE
Compile with disable-sandbox flag in order for homebrew support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,8 @@ end
 
 def spm_build(configuration)
   spm_cmd = "swift build "\
-            "-c #{configuration}"
+            "-c #{configuration} "\
+            "--disable-sandbox"
   p spm_cmd
   system(spm_cmd) or abort "Build failure"
 end


### PR DESCRIPTION
This is required to add support for installation via Homebrew. 