### PR TITLE
Don't lose time precision

### DIFF
--- a/Resources/js/app.js
+++ b/Resources/js/app.js
@@ -94,7 +94,7 @@ function drawHeaders(target) {
   if (duration.minutes() > 0) {
     durationText += duration.minutes() + ' mins, ';
   }
-  durationText += duration.seconds() + ' secs';
+  durationText += Math.round(duration.seconds()) + ' secs';
   document.getElementById('build-time').innerHTML = durationText;
   document.getElementById('targets').innerHTML = targets.length.toLocaleString('en');
   document.getElementById('c-files').innerHTML = cFiles.length.toLocaleString('en');
@@ -240,11 +240,10 @@ function drawTimeline(target) {
         const serie = dataSeries[dataPointIndex];
         const start = serie.start;
         const end = serie.end;
-        const duration = end - start;
-        const seconds = duration === 1 ? " second" : " seconds";
+        const duration = (end - start).toFixed(3);
         return '<div class="arrow_box">' +
           '<span>' + serie.x + ' </span><br>' +
-          '<span>' + duration + seconds + '</span>' +
+          '<span>' + duration + ' seconds</span>' +
           '</div>'
       },
       y: {
@@ -283,7 +282,7 @@ function drawSlowestTargets(target) {
   const top = Math.min(20, targetsData.length);
   const topTargets = targetsData.slice(0, top);
   const durations = topTargets.map(function (target) {
-    return target.duration;
+    return target.duration.toFixed(3);
   });
   const names = topTargets.map(function (step) {
     if (target === 'main') {
@@ -349,7 +348,7 @@ function drawSlowestFiles(collection, element) {
   const top = Math.min(20, sortedData.length);
   const topTargets = sortedData.slice(0, top);
   const durations = topTargets.map(function (target) {
-    return target.duration;
+    return target.duration.toFixed(3);
   });
   const names = topTargets.map(function (step) {
     return getShortFilename(step.title, step.architecture);

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -167,15 +167,15 @@ public struct BuildStep: Encodable {
     /// - Some subSteps may have a startTimestamp before the main's startTimestamp.
     /// That behaviour has been found in steps of `DetailStepType.copyResourceFile`.
     /// Probably meaning that the file was cached
-    public let startTimestamp: Int64
+    public let startTimestamp: Double
 
     /// The timestap in which the step ended represented as Unix epoch
     /// For steps of type BuildStepType.main this is the date in which the build ended
-    public let endTimestamp: Int64
+    public let endTimestamp: Double
 
     /// The number of seconds the step lasted.
     /// For steps of type BuildStepType.main this is the total duration of the build.
-    public let duration: Int64
+    public let duration: Double
 
     /// For builds of type
     public let detailStepType: DetailStepType

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -159,11 +159,11 @@ public final class ParserBuildSteps {
         return dateFormatter.string(from: Date(timeIntervalSinceReferenceDate: timeInterval))
     }
 
-    private func toTimestampSince1970(timeInterval: Double) -> Int64 {
-        return Int64(round(Date(timeIntervalSinceReferenceDate: timeInterval).timeIntervalSince1970))
+    private func toTimestampSince1970(timeInterval: Double) -> Double {
+        return Date(timeIntervalSinceReferenceDate: timeInterval).timeIntervalSince1970
     }
 
-    private func getDuration(startTimeInterval: Double, endTimeInterval: Double) -> Int64 {
+    private func getDuration(startTimeInterval: Double, endTimeInterval: Double) -> Double {
         var duration = endTimeInterval - startTimeInterval
         //If the endtime is almost the same as the endtime, we got a constant
         //in the tokens and a date in the future (year 4001). Here we normalize it to 0.0 secs
@@ -171,7 +171,7 @@ public final class ParserBuildSteps {
             duration = 0.0
         }
         duration = duration >= 0 ? duration : 0.0
-        return Int64(round(duration))
+        return duration
     }
 
     private func getSchema(title: String) -> String {

--- a/Sources/XCLogParser/reporter/ChromeTracerReporter.swift
+++ b/Sources/XCLogParser/reporter/ChromeTracerReporter.swift
@@ -44,7 +44,7 @@ public struct ChromeTracerReporter: LogReporter {
                                     pid: 1,
                                     tid: index,
                                     cat: target.title,
-                                    ts: Double(target.startTimestamp) * microSecondsPerSecond,
+                                    ts: target.startTimestamp * microSecondsPerSecond,
                                     id: index)
 
         let endEvent = TrackEvent(name: target.title,
@@ -52,7 +52,7 @@ public struct ChromeTracerReporter: LogReporter {
                                   pid: 1,
                                   tid: index,
                                   cat: target.title,
-                                  ts: Double(target.endTimestamp) * microSecondsPerSecond,
+                                  ts: target.endTimestamp * microSecondsPerSecond,
                                   id: index)
         return [startEvent, endEvent]
     }
@@ -63,9 +63,9 @@ public struct ChromeTracerReporter: LogReporter {
                                 pid: 1,
                                 tid: index,
                                 cat: target.title,
-                                ts: Double(step.startTimestamp) * microSecondsPerSecond,
+                                ts: step.startTimestamp * microSecondsPerSecond,
                                 id: index,
-                                dur: Double(step.duration) * microSecondsPerSecond)
+                                dur: step.duration * microSecondsPerSecond)
         event.args["signature"] = step.signature
         event.args["type"] = step.detailStepType.rawValue
         return event


### PR DESCRIPTION
- There are many build steps that take only milliseconds (such as copying small resource files)
- Rounding everything to a second causes overlaps in time. etc.
- There's no good reason to lose the precise data we already have (could round at the very end for the UI)