### PR TITLE
Parse DBGConsoleLog

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -216,7 +216,8 @@ public class ActivityParser {
             else {
                 throw Error.parseError("Unexpected token found parsing IDEActivityLogSection \(classRefToken)")
         }
-        if className == String(describing: IDEActivityLogSection.self) {
+        if className == String(describing: IDEActivityLogSection.self)
+        || className == "DBGConsoleLog" {
             return try parseIDEActivityLogSection(iterator: &iterator)
         }
         if className == "IDECommandLineBuildLog" {

--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -135,6 +135,32 @@ public class ActivityParser {
                                          performanceTestOutputString: try parseAsString(token: iterator.next()))
     }
 
+    public func parseDBGConsoleLog(iterator: inout IndexingIterator<[Token]>)
+        throws -> DBGConsoleLog {
+            return DBGConsoleLog(sectionType: Int8(try parseAsInt(token: iterator.next())),
+                                                 domainType: try parseAsString(token: iterator.next()),
+                                                 title: try parseAsString(token: iterator.next()),
+                                                 signature: try parseAsString(token: iterator.next()),
+                                                 timeStartedRecording: try parseAsDouble(token: iterator.next()),
+                                                 timeStoppedRecording: try parseAsDouble(token: iterator.next()),
+                                                 subSections: try parseIDEActivityLogSections(iterator: &iterator),
+                                                 text: try parseAsString(token: iterator.next()),
+                                                 messages: try parseMessages(iterator: &iterator),
+                                                 wasCancelled: try parseBoolean(token: iterator.next()),
+                                                 isQuiet: try parseBoolean(token: iterator.next()),
+                                                 wasFetchedFromCache: try parseBoolean(token: iterator.next()),
+                                                 subtitle: try parseAsString(token: iterator.next()),
+                                                 location: try parseDocumentLocation(iterator: &iterator),
+                                                 commandDetailDesc: try parseAsString(token: iterator.next()),
+                                                 uniqueIdentifier: try parseAsString(token: iterator.next()),
+                                                 localizedResultString: try parseAsString(token: iterator.next()),
+                                                 xcbuildSignature: try parseAsString(token: iterator.next()),
+                                                 // swiftlint:disable:next line_length
+                                                 unknown: isCommandLineLog ? Int(try parseAsInt(token: iterator.next())) : 0,
+                                                 logConsoleItems: try parseIDEConsoleItems(iterator: &iterator)
+                                                 )
+    }
+
     private func parseMessages(iterator: inout IndexingIterator<[Token]>) throws -> [IDEActivityLogMessage] {
         guard let listToken = iterator.next() else {
             throw Error.parseError("Parsing [IDEActivityLogMessage]")
@@ -216,8 +242,7 @@ public class ActivityParser {
             else {
                 throw Error.parseError("Unexpected token found parsing IDEActivityLogSection \(classRefToken)")
         }
-        if className == String(describing: IDEActivityLogSection.self)
-        || className == "DBGConsoleLog" {
+        if className == String(describing: IDEActivityLogSection.self) {
             return try parseIDEActivityLogSection(iterator: &iterator)
         }
         if className == "IDECommandLineBuildLog" {
@@ -226,7 +251,10 @@ public class ActivityParser {
         if className == "IDEActivityLogUnitTestSection" {
             return try parseIDEActivityLogUnitTestSection(iterator: &iterator)
         }
-        throw Error.parseError("Unexpected className found parsi3ng IDEActivityLogSection \(className)")
+        if className == String(describing: DBGConsoleLog.self) {
+            return try parseDBGConsoleLog(iterator: &iterator)
+        }
+        throw Error.parseError("Unexpected className found parsing IDEActivityLogSection \(className)")
     }
 
     private func getClassRefToken(iterator: inout IndexingIterator<[Token]>) throws -> Token {
@@ -266,6 +294,46 @@ public class ActivityParser {
                 return sections
             default:
                 throw Error.parseError("Unexpected token parsing array of IDEActivityLogSection: \(listToken)")
+            }
+    }
+
+    private func parseIDEConsoleItem(iterator: inout IndexingIterator<[Token]>)
+        throws -> IDEConsoleItem? {
+            let classRefToken = try getClassRefToken(iterator: &iterator)
+            if case Token.null = classRefToken {
+               return nil
+            }
+            guard case Token.classNameRef(let className) = classRefToken else {
+                throw Error.parseError("Unexpected token found parsing IDEConsoleItem \(classRefToken)")
+            }
+
+            if className == String(describing: IDEConsoleItem.self) {
+                return IDEConsoleItem(adaptorType: try parseAsInt(token: iterator.next()),
+                                      content: try parseAsString(token: iterator.next()),
+                                      kind: try parseAsInt(token: iterator.next()),
+                                      timestamp: try parseAsDouble(token: iterator.next()))
+            }
+            throw Error.parseError("Unexpected className found parsing IDEConsoleItem \(className)")
+    }
+
+    private func parseIDEConsoleItems(iterator: inout IndexingIterator<[Token]>)
+        throws -> [IDEConsoleItem] {
+            guard let listToken = iterator.next() else {
+                throw Error.parseError("Unexpected EOF parsing array of IDEConsoleItem")
+            }
+            switch listToken {
+            case .null:
+                return [IDEConsoleItem]()
+            case .list(let count):
+                var items = [IDEConsoleItem]()
+                for _ in 0..<count {
+                    if let item = try parseIDEConsoleItem(iterator: &iterator) {
+                        items.append(item)
+                    }
+                }
+                return items
+            default:
+                throw Error.parseError("Unexpected token parsing array of IDEConsoleItem: \(listToken)")
             }
     }
 

--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -167,7 +167,7 @@ public class ActivityParser {
         }
         switch listToken {
         case .null:
-            return [IDEActivityLogMessage]()
+            return []
         case .list(let count):
             var messages = [IDEActivityLogMessage]()
             for _ in 0..<count {
@@ -186,7 +186,7 @@ public class ActivityParser {
         }
         switch listToken {
         case .null:
-            return [DVTDocumentLocation]()
+            return []
         case .list(let count):
             var locations = [DVTDocumentLocation]()
             for _ in 0..<count {
@@ -284,7 +284,7 @@ public class ActivityParser {
             }
             switch listToken {
             case .null:
-                return [IDEActivityLogSection]()
+                return []
             case .list(let count):
                 var sections = [IDEActivityLogSection]()
                 for _ in 0..<count {
@@ -323,7 +323,7 @@ public class ActivityParser {
             }
             switch listToken {
             case .null:
-                return [IDEConsoleItem]()
+                return []
             case .list(let count):
                 var items = [IDEConsoleItem]()
                 for _ in 0..<count {

--- a/Sources/XCLogParser/activityparser/IDEActivityModel.swift
+++ b/Sources/XCLogParser/activityparser/IDEActivityModel.swift
@@ -250,3 +250,66 @@ public class DVTTextDocumentLocation: DVTDocumentLocation {
         try container.encode(locationEncoding, forKey: .locationEncoding)
     }
 }
+
+public struct IDEConsoleItem: Encodable {
+    public let adaptorType: UInt64
+    public let content: String
+    public let kind: UInt64
+    public let timestamp: Double
+}
+
+public class DBGConsoleLog: IDEActivityLogSection {
+    public let logConsoleItems: [IDEConsoleItem]
+
+    public init(sectionType: Int8,
+                domainType: String,
+                title: String,
+                signature: String,
+                timeStartedRecording: Double,
+                timeStoppedRecording: Double,
+                subSections: [IDEActivityLogSection],
+                text: String,
+                messages: [IDEActivityLogMessage],
+                wasCancelled: Bool,
+                isQuiet: Bool,
+                wasFetchedFromCache: Bool,
+                subtitle: String,
+                location: DVTDocumentLocation,
+                commandDetailDesc: String,
+                uniqueIdentifier: String,
+                localizedResultString: String,
+                xcbuildSignature: String,
+                unknown: Int,
+                logConsoleItems: [IDEConsoleItem]) {
+        self.logConsoleItems = logConsoleItems
+        super.init(sectionType: sectionType,
+                   domainType: domainType,
+                   title: title,
+                   signature: signature,
+                   timeStartedRecording: timeStartedRecording,
+                   timeStoppedRecording: timeStoppedRecording,
+                   subSections: subSections,
+                   text: text,
+                   messages: messages,
+                   wasCancelled: wasCancelled,
+                   isQuiet: isQuiet,
+                   wasFetchedFromCache: wasFetchedFromCache,
+                   subtitle: subtitle,
+                   location: location,
+                   commandDetailDesc: commandDetailDesc,
+                   uniqueIdentifier: uniqueIdentifier,
+                   localizedResultString: localizedResultString,
+                   xcbuildSignature: xcbuildSignature,
+                   unknown: unknown)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case logConsoleItems
+    }
+
+    override public func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(logConsoleItems, forKey: .logConsoleItems)
+    }
+}


### PR DESCRIPTION
Adds support to parse logs that contain instances of  `DBGConsoleLog` to close the issue https://github.com/spotify/XCLogParser/issues/9.

The `dump` commands can handle those classes that are subclasses of `IDEActivityLogSection` with an additional property called `logConsoleItems` that contains instances of `IDEConsoleItem`.
The `parse` command is not currently using that new data. We can add data from it if we find it useful in the future 

Output of the `dump` command:

```json
{
  "version" : 10,
  "mainSection" : {
    "location" : {
      "documentURLString" : "",
      "timestamp" : 0
    },
    "title" : "Debug iOSDemo",
    "wasFetchedFromCache" : false,
    "messages" : [

    ],
    "logConsoleItems" : [
      {
        "adaptorType" : 2,
        "content" : "error: failed to launch '\/private\/var\/containers\/Bundle\/Application\/33DADF20-54AC-4948-A344-6EEAA2372E7A\/iOSDemo.app'",
        "kind" : 10,
        "timestamp" : 582169311.44149995
      },
      {
        "adaptorType" : 2,
        "content" : " -- Verify the Developer App certificate for your account is trusted on your device. Open Settings on iPhone and navigate to General -> Device Management, then select your Developer App certificate to trust it.\r",
        "kind" : 10,
        "timestamp" : 582169311.44156301
      },
      {
        "adaptorType" : 2,
        "content" : "Internal launch error: process launch failed: Security\r",
        "kind" : 10,
        "timestamp" : 582169311.44156599
      }
    ],
    "uniqueIdentifier" : "79D9C1DE-F736-4743-A7C6-B08ED42A1DFE",
    "timeStartedRecording" : 582169296.79349506,
    "commandDetailDesc" : "",
    "localizedResultString" : "",
    "timeStoppedRecording" : 582169312.03907502,
    "signature" : "Debug iOSDemo",
    "subSections" : [

    ],
    "xcbuildSignature" : "",
    "wasCancelled" : false,
    "domainType" : "Xcode.IDEActivityLogDomainType.DebugLog",
    "subtitle" : "",
    "unknown" : 0,
    "sectionType" : 0,
    "text" : "",
    "isQuiet" : false
  }
}
Program ended with exit code: 0
```