### PR TITLE
Support for Xcode11-beta

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -245,7 +245,9 @@ public class ActivityParser {
         if className == String(describing: IDEActivityLogSection.self) {
             return try parseIDEActivityLogSection(iterator: &iterator)
         }
-        if className == "IDECommandLineBuildLog" {
+        if className == "IDECommandLineBuildLog" ||
+            className == "IDEActivityLogMajorGroupSection" ||
+            className == "IDEActivityLogCommandInvocationSection" {
             return try parseIDEActivityLogSection(iterator: &iterator)
         }
         if className == "IDEActivityLogUnitTestSection" {


### PR DESCRIPTION
Xcode11's logs have two new classes that inherit from `IDEActivityLogSection` and don't add new properties. I tested it by parsing build logs and logs from the `Issues` folder.