### PR TITLE
Add public initializer to ActivityParser

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -29,6 +29,8 @@ public class ActivityParser {
     /// that into account
     var isCommandLineLog = false
 
+    public init() {}
+
     /// Parses the xcacticitylog argument into a `IDEActivityLog`
     /// - parameter logURL: `URL` of the xcactivitylog
     /// - parameter redacted: If true, the username will be replaced


### PR DESCRIPTION
While trying to use it from another SPM project, I realised the initiliazer wasn't public 