### PR TITLE
Make API public

### DIFF
--- a/Sources/XCLogParser/loglocation/LogFinder.swift
+++ b/Sources/XCLogParser/loglocation/LogFinder.swift
@@ -44,6 +44,8 @@ public struct LogFinder {
         return homeDirURL.appendingPathComponent("Library/Developer/Xcode/DerivedData", isDirectory: true)
     }
 
+    public init() {}
+
     public func findLatestLogWithLogOptions(_ logOptions: LogOptions) throws -> URL {
         guard logOptions.xcactivitylogPath.isEmpty else {
             return URL(fileURLWithPath: Path(logOptions.xcactivitylogPath).absolute().string)

--- a/Sources/XCLogParser/parser/FunctionTime.swift
+++ b/Sources/XCLogParser/parser/FunctionTime.swift
@@ -22,17 +22,17 @@ import Foundation
 /// Represents the time it took to the Swift Compiler to compile a function
 public struct FunctionTime: Encodable {
     /// URL of the file where the function is
-    let file: String
+    public let file: String
 
     /// Duration in Miliseconds
-    let durationMS: Double
+    public let durationMS: Double
 
     /// Line number where the function is declared
-    let startingLine: Int
+    public let startingLine: Int
 
     /// Column number where the function is declared
-    let startingColumn: Int
+    public let startingColumn: Int
 
     /// function signature
-    let signature: String
+    public let signature: String
 }

--- a/Sources/XCLogParser/parser/Notice.swift
+++ b/Sources/XCLogParser/parser/Notice.swift
@@ -70,15 +70,15 @@ public enum NoticeType: String, Encodable {
 /// wraps that data
 public class Notice: Encodable {
 
-    let type: NoticeType
-    let title: String
-    let clangFlag: String?
-    let documentURL: String
-    let severity: Int
-    let startingLineNumber: UInt64
-    let endingLineNumber: UInt64
-    let startingColumnNumber: UInt64
-    let endingColumnNumber: UInt64
+    public let type: NoticeType
+    public let title: String
+    public let clangFlag: String?
+    public let documentURL: String
+    public let severity: Int
+    public let startingLineNumber: UInt64
+    public let endingLineNumber: UInt64
+    public let startingColumnNumber: UInt64
+    public let endingColumnNumber: UInt64
     public let characterRangeEnd: UInt64
     public let characterRangeStart: UInt64
 


### PR DESCRIPTION
Changes the visibility to public to the functions and properties that are needed to be able to use the project as a dependency in another Swift Package.