### PR TITLE
Fix note parsing

### DIFF
--- a/Sources/XCLogParser/parser/Notice.swift
+++ b/Sources/XCLogParser/parser/Notice.swift
@@ -61,7 +61,7 @@ public enum NoticeType: String, Encodable {
         case Suffix("Notice"):
             return .note
         default:
-            return nil
+            return .note
         }
     }
 }
@@ -127,7 +127,7 @@ public class Notice: Encodable {
     /// - returns: An Array of `Notice`
     public static func parseFromLogSection(_ logSection: IDEActivityLogSection) -> [Notice] {
         // we look for clangWarnings parsing the text of the logSection
-        // is it possible to have errors and clang warning in the same step?
+        // is it possible to have errors and clang warnings in the same step?
         if let clangWarningsFlags = self.parseClangWarningFlags(text: logSection.text),
             clangWarningsFlags.count > 0 {
             return zip(logSection.messages, clangWarningsFlags).compactMap { (message, warningFlag) -> Notice? in

--- a/Tests/XCLogParserTests/ParserTests.swift
+++ b/Tests/XCLogParserTests/ParserTests.swift
@@ -70,4 +70,92 @@ class ParserTests: XCTestCase {
         }
     }
 
+    func testParseNote() throws {
+        let timestamp = Date().timeIntervalSinceReferenceDate
+
+        let noteMessage = IDEActivityLogMessage(title: "Using legacy build system",
+            shortTitle: "",
+            timeEmitted: timestamp,
+            rangeEndInSectionText: 18446744073709551615,
+            rangeStartInSectionText: 0,
+            subMessages: [],
+            severity: 0,
+            type: "",
+            location: DVTDocumentLocation(documentURLString: "", timestamp: timestamp),
+            categoryIdent: "",
+            secondaryLocations: [],
+            additionalDescription: "")
+        let fakeLog = getFakeIDEActivityLogWithMessage(noteMessage,
+                                                       andText: "text")
+        let build = try parser.parse(activityLog: fakeLog)
+        XCTAssertNotNil(build.notes, "Build's notes are empty")
+        guard let note = build.notes?.first else {
+            XCTFail("There should be one note")
+            return
+        }
+        XCTAssertEqual(noteMessage.title, note.title)
+    }
+
+    func testParseWarning() throws {
+        let timestamp = Date().timeIntervalSinceReferenceDate
+
+        let textDocumentLocation = DVTTextDocumentLocation(documentURLString: "file://project/file.m",
+                                                           timestamp: timestamp,
+                                                           startingLineNumber: 10,
+                                                           startingColumnNumber: 11,
+                                                           endingLineNumber: 12,
+                                                           endingColumnNumber: 13,
+                                                           characterRangeEnd: 14,
+                                                           characterRangeStart: 15,
+                                                           locationEncoding: 16)
+        let warningMessage = IDEActivityLogMessage(title: "ABC is deprecated",
+                                                shortTitle: "",
+                                                timeEmitted: timestamp,
+                                                rangeEndInSectionText: 18446744073709551615,
+                                                rangeStartInSectionText: 0,
+                                                subMessages: [],
+                                                severity: 1,
+                                                type: "com.apple.dt.IDE.diagnostic",
+                                                location: textDocumentLocation,
+                                                categoryIdent: "",
+                                                secondaryLocations: [],
+                                                additionalDescription: "")
+        let fakeLog = getFakeIDEActivityLogWithMessage(warningMessage,
+                                                       andText: "This is deprecated, [-Wdeprecated-declarations]")
+        let build = try parser.parse(activityLog: fakeLog)
+        XCTAssertNotNil(build.warnings, "Warnings shouldn't be empty")
+        guard let warning = build.warnings?.first else {
+            XCTFail("Build's warnings are empty")
+            return
+        }
+        XCTAssertEqual(warningMessage.title, warning.title)
+        XCTAssertEqual("[-Wdeprecated-declarations]", warning.clangFlag ?? "empty")
+    }
+
+    private func getFakeIDEActivityLogWithMessage(_ message: IDEActivityLogMessage,
+                                                  andText text: String) -> IDEActivityLog {
+        let timestamp = Date().timeIntervalSinceReferenceDate
+        let fakeMainStep = IDEActivityLogSection(sectionType: 1,
+                                                 domainType: "",
+                                                 title: "",
+                                                 signature: "",
+                                                 timeStartedRecording: timestamp,
+                                                 timeStoppedRecording: timestamp,
+                                                 subSections: [],
+                                                 text: text,
+                                                 messages: [message],
+                                                 wasCancelled: false,
+                                                 isQuiet: true,
+                                                 wasFetchedFromCache: true,
+                                                 subtitle: "",
+                                                 location: DVTDocumentLocation(documentURLString: "",
+                                                                               timestamp: timestamp),
+                                                 commandDetailDesc: "",
+                                                 uniqueIdentifier: "uniqueIdentifier",
+                                                 localizedResultString: "",
+                                                 xcbuildSignature: "",
+                                                 unknown: 0)
+        return IDEActivityLog(version: 10, mainSection: fakeMainStep)
+    }
+
 }

--- a/Tests/XCLogParserTests/ParserTests.swift
+++ b/Tests/XCLogParserTests/ParserTests.swift
@@ -72,7 +72,6 @@ class ParserTests: XCTestCase {
 
     func testParseNote() throws {
         let timestamp = Date().timeIntervalSinceReferenceDate
-
         let noteMessage = IDEActivityLogMessage(title: "Using legacy build system",
             shortTitle: "",
             timeEmitted: timestamp,
@@ -98,7 +97,6 @@ class ParserTests: XCTestCase {
 
     func testParseWarning() throws {
         let timestamp = Date().timeIntervalSinceReferenceDate
-
         let textDocumentLocation = DVTTextDocumentLocation(documentURLString: "file://project/file.m",
                                                            timestamp: timestamp,
                                                            startingLineNumber: 10,


### PR DESCRIPTION
Xcode adds some Messages without a `categoryIdent` to identify them, most prominently the one about which Build system is being used. This PR make those without a category a `Note` by default