### PR TITLE
Parse class IBMemberDocumentLocation

### DIFF
--- a/Sources/XCLogParser/activityparser/IDEActivityModel.swift
+++ b/Sources/XCLogParser/activityparser/IDEActivityModel.swift
@@ -457,8 +457,8 @@ public class DBGConsoleLog: IDEActivityLogSection {
 }
 
 public class IDEActivityLogAnalyzerControlFlowStepEdge: Encodable {
-    let startLocation: DVTDocumentLocation
-    let endLocation: DVTDocumentLocation
+    public let startLocation: DVTDocumentLocation
+    public let endLocation: DVTDocumentLocation
 
     public init(startLocation: DVTDocumentLocation, endLocation: DVTDocumentLocation) {
         self.startLocation = startLocation
@@ -468,9 +468,9 @@ public class IDEActivityLogAnalyzerControlFlowStepEdge: Encodable {
 
 public class IDEActivityLogAnalyzerEventStepMessage: IDEActivityLogMessage {
 
-    let parentIndex: UInt64
-    let description: String
-    let callDepth: UInt64
+    public let parentIndex: UInt64
+    public let description: String
+    public let callDepth: UInt64
 
     public init(title: String,
                 shortTitle: String,
@@ -518,5 +518,53 @@ public class IDEActivityLogAnalyzerEventStepMessage: IDEActivityLogMessage {
         try container.encode(description, forKey: .description)
         try container.encode(parentIndex, forKey: .parentIndex)
         try container.encode(callDepth, forKey: .callDepth)
+    }
+}
+
+// MARK: IDEInterfaceBuilderKit
+
+public class IBMemberID: Encodable {
+    public let memberIdentifier: String
+
+    public init(memberIdentifier: String) {
+        self.memberIdentifier = memberIdentifier
+    }
+}
+
+public class IBAttributeSearchLocation: Encodable {
+    public let offsetFromStart: UInt64
+    public let offsetFromEnd: UInt64
+    public let keyPath: String
+
+    public init(offsetFromStart: UInt64, offsetFromEnd: UInt64, keyPath: String) {
+        self.offsetFromEnd = offsetFromEnd
+        self.offsetFromStart = offsetFromStart
+        self.keyPath = keyPath
+    }
+}
+
+public class IBDocumentMemberLocation: DVTDocumentLocation {
+    public let memberIdentifier: IBMemberID
+    public let attributeSearchLocation: IBAttributeSearchLocation?
+
+    public init(documentURLString: String,
+                timestamp: Double,
+                memberIdentifier: IBMemberID,
+                attributeSearchLocation: IBAttributeSearchLocation?) {
+        self.memberIdentifier = memberIdentifier
+        self.attributeSearchLocation = attributeSearchLocation
+        super.init(documentURLString: documentURLString, timestamp: timestamp)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case memberIdentifier
+        case attributeSearchLocation
+    }
+
+    override public func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(memberIdentifier, forKey: .memberIdentifier)
+        try container.encode(attributeSearchLocation, forKey: .attributeSearchLocation)
     }
 }

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.1.6"
+    public static let current = "0.1.7"
 
 }

--- a/Sources/XCLogParser/extensions/ArrayExtension.swift
+++ b/Sources/XCLogParser/extensions/ArrayExtension.swift
@@ -37,7 +37,8 @@ extension Array where Element: Notice {
             $0.type == .swiftWarning ||
             $0.type == .clangWarning ||
             $0.type == .projectWarning ||
-            $0.type == .analyzerWarning
+            $0.type == .analyzerWarning ||
+            $0.type == .interfaceBuilderWarning
         }
     }
 

--- a/Tests/XCLogParserTests/ActivityParserTests.swift
+++ b/Tests/XCLogParserTests/ActivityParserTests.swift
@@ -207,6 +207,17 @@ class ActivityParserTests: XCTestCase {
         Token.int(0),
         Token.null]
 
+    let IBDocumentMemberLocationTokens: [Token] = [
+        Token.className("IBDocumentMemberLocation"),
+        Token.classNameRef("IBDocumentMemberLocation"),
+        Token.string("file:///projects/WarningTest/WarningTest/Base.lproj/Main.storyboard"),
+        Token.double(0.0),
+        Token.className("IBMemberID"),
+        Token.classNameRef("IBMemberID"),
+        Token.string("RgO-vd-uiQ"),
+        Token.null
+    ]
+
     func testParseDVTTextDocumentLocation() throws {
         let tokens = textDocumentLocationTokens
         var iterator = tokens.makeIterator()
@@ -299,4 +310,18 @@ class ActivityParserTests: XCTestCase {
         }
     }
 
+    func testParseIBDocumentMemberLocation() throws {
+        var iterator = IBDocumentMemberLocationTokens.makeIterator()
+        let documentLocation = try parser.parseDocumentLocation(iterator: &iterator)
+        XCTAssert(documentLocation is IBDocumentMemberLocation,
+                  "Document location should be a IBDocumentMemberLocation")
+        XCTAssertEqual("file:///projects/WarningTest/WarningTest/Base.lproj/Main.storyboard",
+                       documentLocation.documentURLString, "The url should be correctly parsed")
+        guard let documentMemberLocation = documentLocation as? IBDocumentMemberLocation else {
+            return
+        }
+        XCTAssertEqual("RgO-vd-uiQ",
+                       documentMemberLocation.memberIdentifier.memberIdentifier,
+                       "IBMember's identifier should be parsed")
+    }
 }


### PR DESCRIPTION
Interface builder files generate a new kind of warning, as reported here https://github.com/spotify/XCLogParser/issues/36

This PR adds support to parse such warnings

cc @joshavant