### PR TITLE
Update reporter usage w/ missing reporter

### DIFF
--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -118,7 +118,7 @@ struct ParseOptions: OptionsProtocol {
             <*> mode <| Option(
                 key: "reporter",
                 defaultValue: "",
-                usage: "The reporter to use. It could be `json`, `flatJson`, `chromeTracer`, `html` or `btr`")
+                usage: "The reporter to use. It could be `json`, `flatJson`, `summaryJson`, `chromeTracer`, `html` or `btr`")
             <*> mode <| Option(
                 key: "machine_name",
                 defaultValue: "",

--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -118,7 +118,8 @@ struct ParseOptions: OptionsProtocol {
             <*> mode <| Option(
                 key: "reporter",
                 defaultValue: "",
-                usage: "The reporter to use. It could be `json`, `flatJson`, `summaryJson`, `chromeTracer`, `html` or `btr`")
+                usage: "The reporter to use. It could be `json`, `flatJson`, " +
+		"`summaryJson`, `chromeTracer`, `html` or `btr`")
             <*> mode <| Option(
                 key: "machine_name",
                 defaultValue: "",


### PR DESCRIPTION
A few months ago i added a new reporter: https://github.com/spotify/XCLogParser/pull/27

Unfortunately i forgot to update the reporter's help text! This PR just updates the `usage` description for the `--reporter` option.

Thanks!