### PR TITLE
Speed improvements and a new `fetchedFromCache` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This script assumes that the `xclogparser` executable is installed and present i
 
 >Note: Errors thrown in post-action run scripts are silenced, so it could be hard to notice simple mistakes.
 
+>Note: Since Xcode 11, `xcodebuild` only generates the .xcactivitylog build logs when the option `--resultBundlePath`. If you're compiling with that command and not with Xcode, be sure to set that option to a valid path.
+
 The run script is executed in a temporary directory by Xcode, so you may find it useful to immediately open the generated output with `open MyAppLogs` at the end of the script.
 The Finder will automatically open the output folder after a build completes and you can then view the generated HTML page that contains a nice visualization of your build! ✨
 

--- a/Resources/css/styles.css
+++ b/Resources/css/styles.css
@@ -73,3 +73,7 @@ main.main {
   color: gray;
   text-decoration: none;
 }
+
+.xc-card-body {
+  padding: .75em;
+}

--- a/Resources/index.html
+++ b/Resources/index.html
@@ -36,7 +36,7 @@
             <div class="col-md-2 col-sm-1">
               <div class="card xc-topboxes text-white bg-primary info-box">
                 <div class="card-header" id="schema-title">Schema</div>
-                <div class="card-body">
+                <div class="xc-card-body card-body">
                   <div id="schema" class="card-text"></div>
                 </div> <!-- card body -->
               </div> <!-- card-->
@@ -44,7 +44,7 @@
             <div class="col-md-2 col-sm-1">
               <div id="status-box" class="card xc-topboxes text-white info-box">
                 <div class="card-header">Build status</div>
-                <div class="card-body">
+                <div class="xc-card-body card-body">
                   <div id="build-status" class="card-text"></div>
                 </div> <!-- card body -->
               </div> <!-- card-->
@@ -52,7 +52,7 @@
             <div class="col-md-2 col-sm-1">
               <div class="card text-white xc-topboxes bg-info info-box">
                 <div class="card-header">Build time</div>
-                <div class="card-body">
+                <div class="xc-card-body card-body">
                   <div id="build-time" class="card-text"></div>
                 </div> <!-- card-body -->
               </div> <!-- card -->
@@ -61,7 +61,7 @@
             <div class="col-md-2 col-sm-1">
               <div class="card text-white xc-topboxes bg-info info-box">
                 <div class="card-header" id="targets-title">Number of targets</div>
-                <div class="card-body">
+                <div class="xc-card-body card-body">
                   <div id="targets" class="card-text"></div>
                 </div> <!-- card-body -->
               </div> <!-- card -->
@@ -70,8 +70,19 @@
             <div class="col-md-2 col-sm-1">
               <div class="card text-white xc-topboxes objc info-box">
                 <div class="card-header">C files</div>
-                <div class="card-body">
-                  <div id="c-files" class="card-text"></div>
+                <div class="xc-card-body card-body">
+                  <div class="card-block">
+                    <div class="row">
+                        <div class="col">
+                          <div id="c-files-compiled" class="card-text"></div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col">
+                          <div id="c-files-total" class="card-text"></div>
+                        </div>
+                    </div>
+                  </div> <!-- card-block -->
                 </div> <!-- card-body -->
               </div> <!-- card -->
             </div>
@@ -79,8 +90,19 @@
             <div class="col-md-2 col-sm-1">
               <div class="card text-white xc-topboxes swift info-box">
                   <div class="card-header">Swift files</div>
-                <div class="card-body">
-                  <div id="swift-files" class="card-text"></div>
+                <div class="xc-card-body card-body">
+                  <div class="card-block">
+                    <div class="row">
+                      <div class="col">
+                        <div id="swift-files-compiled" class="card-text"></div>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div class="col">
+                        <div id="swift-files-total" class="card-text"></div>
+                      </div>
+                    </div>
+                  </div> <!-- card-block -->
                 </div> <!-- card-body -->
               </div> <!-- card -->
             </div>

--- a/Resources/js/app.js
+++ b/Resources/js/app.js
@@ -97,8 +97,16 @@ function drawHeaders(target) {
   durationText += Math.round(duration.seconds()) + ' secs';
   document.getElementById('build-time').innerHTML = durationText;
   document.getElementById('targets').innerHTML = targets.length.toLocaleString('en');
-  document.getElementById('c-files').innerHTML = cFiles.length.toLocaleString('en');
-  document.getElementById('swift-files').innerHTML = swiftFiles.length.toLocaleString('en');
+  const cCompiledFiles = cFiles.filter(function (file) {
+    return file.fetchedFromCache == false;
+  })
+  const swiftCompiledFiles = swiftFiles.filter(function (file) {
+    return file.fetchedFromCache == false;
+  })
+  document.getElementById('c-files-compiled').innerHTML = cCompiledFiles.length.toLocaleString('en') + ' compiled';
+  document.getElementById('c-files-total').innerHTML = cFiles.length.toLocaleString('en') + ' total';
+  document.getElementById('swift-files-compiled').innerHTML = swiftCompiledFiles.length.toLocaleString('en') + ' compiled';
+  document.getElementById('swift-files-total').innerHTML = swiftFiles.length.toLocaleString('en') + ' total';
 
 }
 

--- a/Resources/js/step.js
+++ b/Resources/js/step.js
@@ -44,10 +44,15 @@ const timestampFormat = 'MMMM Do YYYY, h:mm:ss a';
 
 showStep();
 
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+});
+
 function showStep() {
   const step = loadStep();
   if (step != null) {
     $('#info-title').html(step.title);
+    $('#info-cache').html(step.fetchedFromCache);
     $('#info-signature').html(step.signature);
     $('#info-arch').html(step.architecture);
     $('#info-url').html(step.documentURL);

--- a/Resources/step.html
+++ b/Resources/step.html
@@ -57,6 +57,17 @@
                   </div>
                   <div class="row">
                     <div class="col-sm-2">
+                      Fetched from cache
+                    </div>
+                    <div class="col-sm-10">
+                      <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="right" title="If true, the target or file wasn't compiled but fetched from Xcode's internal cache">
+                        <div id="info-cache" href=""></div>
+                      </button>
+
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="col-sm-2">
                       Duration
                     </div>
                     <div class="col-sm-10">

--- a/Sources/XCLogParser/activityparser/IDEActivityModel.swift
+++ b/Sources/XCLogParser/activityparser/IDEActivityModel.swift
@@ -42,7 +42,7 @@ public class IDEActivityLogSection: Encodable {
     public let messages: [IDEActivityLogMessage]
     public let wasCancelled: Bool
     public let isQuiet: Bool
-    public let wasFetchedFromCache: Bool
+    public var wasFetchedFromCache: Bool
     public let subtitle: String
     public let location: DVTDocumentLocation
     public let commandDetailDesc: String

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.0"
+    public static let current = "0.2.1"
 
 }

--- a/Sources/XCLogParser/generated/HtmlReporterResources.swift
+++ b/Sources/XCLogParser/generated/HtmlReporterResources.swift
@@ -82,6 +82,10 @@ main.main {
   text-decoration: none;
 }
 
+.xc-card-body {
+  padding: .75em;
+}
+
 """
 
       public static let appJS =
@@ -185,8 +189,16 @@ function drawHeaders(target) {
   durationText += Math.round(duration.seconds()) + ' secs';
   document.getElementById('build-time').innerHTML = durationText;
   document.getElementById('targets').innerHTML = targets.length.toLocaleString('en');
-  document.getElementById('c-files').innerHTML = cFiles.length.toLocaleString('en');
-  document.getElementById('swift-files').innerHTML = swiftFiles.length.toLocaleString('en');
+  const cCompiledFiles = cFiles.filter(function (file) {
+    return file.fetchedFromCache == false;
+  })
+  const swiftCompiledFiles = swiftFiles.filter(function (file) {
+    return file.fetchedFromCache == false;
+  })
+  document.getElementById('c-files-compiled').innerHTML = cCompiledFiles.length.toLocaleString('en') + ' compiled';
+  document.getElementById('c-files-total').innerHTML = cFiles.length.toLocaleString('en') + ' total';
+  document.getElementById('swift-files-compiled').innerHTML = swiftCompiledFiles.length.toLocaleString('en') + ' compiled';
+  document.getElementById('swift-files-total').innerHTML = swiftFiles.length.toLocaleString('en') + ' total';
 
 }
 
@@ -621,7 +633,7 @@ public static let indexHTML =
             <div class="col-md-2 col-sm-1">
               <div class="card xc-topboxes text-white bg-primary info-box">
                 <div class="card-header" id="schema-title">Schema</div>
-                <div class="card-body">
+                <div class="xc-card-body card-body">
                   <div id="schema" class="card-text"></div>
                 </div> <!-- card body -->
               </div> <!-- card-->
@@ -629,7 +641,7 @@ public static let indexHTML =
             <div class="col-md-2 col-sm-1">
               <div id="status-box" class="card xc-topboxes text-white info-box">
                 <div class="card-header">Build status</div>
-                <div class="card-body">
+                <div class="xc-card-body card-body">
                   <div id="build-status" class="card-text"></div>
                 </div> <!-- card body -->
               </div> <!-- card-->
@@ -637,7 +649,7 @@ public static let indexHTML =
             <div class="col-md-2 col-sm-1">
               <div class="card text-white xc-topboxes bg-info info-box">
                 <div class="card-header">Build time</div>
-                <div class="card-body">
+                <div class="xc-card-body card-body">
                   <div id="build-time" class="card-text"></div>
                 </div> <!-- card-body -->
               </div> <!-- card -->
@@ -646,7 +658,7 @@ public static let indexHTML =
             <div class="col-md-2 col-sm-1">
               <div class="card text-white xc-topboxes bg-info info-box">
                 <div class="card-header" id="targets-title">Number of targets</div>
-                <div class="card-body">
+                <div class="xc-card-body card-body">
                   <div id="targets" class="card-text"></div>
                 </div> <!-- card-body -->
               </div> <!-- card -->
@@ -655,8 +667,19 @@ public static let indexHTML =
             <div class="col-md-2 col-sm-1">
               <div class="card text-white xc-topboxes objc info-box">
                 <div class="card-header">C files</div>
-                <div class="card-body">
-                  <div id="c-files" class="card-text"></div>
+                <div class="xc-card-body card-body">
+                  <div class="card-block">
+                    <div class="row">
+                        <div class="col">
+                          <div id="c-files-compiled" class="card-text"></div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col">
+                          <div id="c-files-total" class="card-text"></div>
+                        </div>
+                    </div>
+                  </div> <!-- card-block -->
                 </div> <!-- card-body -->
               </div> <!-- card -->
             </div>
@@ -664,8 +687,19 @@ public static let indexHTML =
             <div class="col-md-2 col-sm-1">
               <div class="card text-white xc-topboxes swift info-box">
                   <div class="card-header">Swift files</div>
-                <div class="card-body">
-                  <div id="swift-files" class="card-text"></div>
+                <div class="xc-card-body card-body">
+                  <div class="card-block">
+                    <div class="row">
+                      <div class="col">
+                        <div id="swift-files-compiled" class="card-text"></div>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <div class="col">
+                        <div id="swift-files-total" class="card-text"></div>
+                      </div>
+                    </div>
+                  </div> <!-- card-block -->
                 </div> <!-- card-body -->
               </div> <!-- card -->
             </div>
@@ -912,6 +946,17 @@ public static let stepHTML =
                   </div>
                   <div class="row">
                     <div class="col-sm-2">
+                      Fetched from cache
+                    </div>
+                    <div class="col-sm-10">
+                      <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="right" title="If true, the target or file wasn't compiled but fetched from Xcode's internal cache">
+                        <div id="info-cache" href=""></div>
+                      </button>
+
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="col-sm-2">
                       Duration
                     </div>
                     <div class="col-sm-10">
@@ -1118,10 +1163,15 @@ const timestampFormat = 'MMMM Do YYYY, h:mm:ss a';
 
 showStep();
 
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+});
+
 function showStep() {
   const step = loadStep();
   if (step != null) {
     $('#info-title').html(step.title);
+    $('#info-cache').html(step.fetchedFromCache);
     $('#info-signature').html(step.signature);
     $('#info-arch').html(step.architecture);
     $('#info-url').html(step.documentURL);

--- a/Sources/XCLogParser/lexer/Lexer.swift
+++ b/Sources/XCLogParser/lexer/Lexer.swift
@@ -27,7 +27,7 @@ public final class Lexer {
     let typeDelimiters: CharacterSet
     let filePath: String
     var classNames = [String]()
-    var userDirToRedact: String? = nil
+    var userDirToRedact: String?
 
     lazy var userDirRegex: NSRegularExpression? = {
         do {

--- a/Sources/XCLogParser/lexer/Lexer.swift
+++ b/Sources/XCLogParser/lexer/Lexer.swift
@@ -22,10 +22,12 @@ import Foundation
 public final class Lexer {
 
     static let SLFHeader = "SLF"
+    static let redactedTemplate = "/Users/<redacted>/"
 
     let typeDelimiters: CharacterSet
     let filePath: String
     var classNames = [String]()
+    var userDirToRedact: String? = nil
 
     lazy var userDirRegex: NSRegularExpression? = {
         do {
@@ -203,13 +205,19 @@ public final class Lexer {
         guard let regex = userDirRegex else {
             return string
         }
-
-        return regex.stringByReplacingMatches(in: string,
-                                              options: .reportProgress,
-                                              range: NSRange(location: 0, length: string.count),
-                                              withTemplate: "/Users/<redacted>/")
+        if let userDirToRedact = userDirToRedact {
+            return string.replacingOccurrences(of: userDirToRedact, with: Self.redactedTemplate)
+        } else {
+            guard let firstMatch = regex.firstMatch(in: string,
+                                                    options: [],
+                                                    range: NSRange(location: 0, length: string.count)) else {
+                return string
+            }
+            let userDir = string.substring(firstMatch.range)
+            userDirToRedact = userDir
+            return string.replacingOccurrences(of: userDir, with: Self.redactedTemplate)
+        }
     }
-
 }
 
 extension Scanner {

--- a/Sources/XCLogParser/parser/BuildStep+Builder.swift
+++ b/Sources/XCLogParser/parser/BuildStep+Builder.swift
@@ -46,7 +46,8 @@ extension BuildStep {
                          warnings: warnings,
                          errors: errors,
                          notes: notes,
-                         swiftFunctionTimes: swiftFunctionTimes)
+                         swiftFunctionTimes: swiftFunctionTimes,
+                         fetchedFromCache: fetchedFromCache)
     }
 
     func with(title newTitle: String) -> BuildStep {
@@ -74,7 +75,8 @@ extension BuildStep {
                          warnings: warnings,
                          errors: errors,
                          notes: notes,
-                         swiftFunctionTimes: swiftFunctionTimes)
+                         swiftFunctionTimes: swiftFunctionTimes,
+                         fetchedFromCache: fetchedFromCache)
     }
 
     func with(signature newSignature: String) -> BuildStep {
@@ -102,7 +104,8 @@ extension BuildStep {
                          warnings: warnings,
                          errors: errors,
                          notes: notes,
-                         swiftFunctionTimes: swiftFunctionTimes)
+                         swiftFunctionTimes: swiftFunctionTimes,
+                         fetchedFromCache: fetchedFromCache)
     }
 
     func withFilteredNotices() -> BuildStep {
@@ -133,7 +136,8 @@ extension BuildStep {
                          warnings: filteredWarnings,
                          errors: filtereredErrors,
                          notes: filteredNotes,
-                         swiftFunctionTimes: swiftFunctionTimes)
+                         swiftFunctionTimes: swiftFunctionTimes,
+                         fetchedFromCache: fetchedFromCache)
     }
 
     func with(subSteps newSubSteps: [BuildStep]) -> BuildStep {
@@ -161,7 +165,8 @@ extension BuildStep {
                          warnings: warnings,
                          errors: errors,
                          notes: notes,
-                         swiftFunctionTimes: swiftFunctionTimes)
+                         swiftFunctionTimes: swiftFunctionTimes,
+                         fetchedFromCache: fetchedFromCache)
     }
 
     private func filterNotices(_ notices: [Notice]?) -> [Notice]? {

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -221,6 +221,11 @@ public struct BuildStep: Encodable {
     /// If the project was compiled with the swift flags `-Xfrontend -debug-time-function-bodies`
     /// This field will be populated
     public var swiftFunctionTimes: [FunctionTime]?
+
+    /// Indicated if the step was actually processed / compiled or just fetched from Xcode's cache.
+    /// In a compilation step this will be false only if the file was actually compiled.
+    /// in a `target` or `main` step it will be false if at least one sub step wasn't fetched from cache.
+    public let fetchedFromCache: Bool
 }
 
 /// Extension used to flatten the three of a `BuildStep`

--- a/Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift
+++ b/Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift
@@ -108,6 +108,7 @@ extension IDEActivityLogSection {
         -> IDEActivityLogSection {
             if let target = targets[name] {
                 target.timeStoppedRecording = section.timeStoppedRecording
+                target.wasFetchedFromCache = target.wasFetchedFromCache && section.wasFetchedFromCache
                 return target
             }
             return buildTargetSection(name, with: section)

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -20,6 +20,7 @@
 import Foundation
 
 /// Parses the .xcactivitylog into a tree of `BuildStep`
+// swiftlint:disable type_body_length
 public final class ParserBuildSteps {
 
     let machineName: String
@@ -145,7 +146,9 @@ public final class ParserBuildSteps {
                                  warnings: warnings,
                                  errors: errors,
                                  notes: notes,
-                                 swiftFunctionTimes: nil
+                                 swiftFunctionTimes: nil,
+                                 fetchedFromCache: wasFetchedFromCache(parent:
+                                    parentSection, section: logSection)
                                  )
 
             step.subSteps = try logSection.subSections.map { subSection -> BuildStep in
@@ -293,6 +296,13 @@ public final class ParserBuildSteps {
                 return subStep
             }
         }
+    }
+
+    private func wasFetchedFromCache(parent: BuildStep?, section: IDEActivityLogSection) -> Bool {
+        if section.wasFetchedFromCache {
+            return section.wasFetchedFromCache
+        }
+        return parent?.fetchedFromCache ?? false
     }
 
 }

--- a/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
+++ b/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
@@ -77,7 +77,8 @@ class ChromeTracerOutputTests: XCTestCase {
                              warnings: nil,
                              errors: nil,
                              notes: nil,
-                             swiftFunctionTimes: nil
+                             swiftFunctionTimes: nil,
+                             fetchedFromCache: false
                              )
         return root
     }
@@ -109,7 +110,8 @@ class ChromeTracerOutputTests: XCTestCase {
                              warnings: nil,
                              errors: nil,
                              notes: nil,
-                             swiftFunctionTimes: nil
+                             swiftFunctionTimes: nil,
+                             fetchedFromCache: false
                              )
 
         let end2 = end.addingTimeInterval(50 * 100)
@@ -137,7 +139,8 @@ class ChromeTracerOutputTests: XCTestCase {
                                 warnings: nil,
                                 errors: nil,
                                 notes: nil,
-                                swiftFunctionTimes: nil
+                                swiftFunctionTimes: nil,
+                                fetchedFromCache: false
                                 )
         return [target1, target2]
 

--- a/Tests/XCLogParserTests/LexerTests.swift
+++ b/Tests/XCLogParserTests/LexerTests.swift
@@ -96,4 +96,13 @@ class LexerTests: XCTestCase {
         XCTAssertTrue(tokens.count == 7)
 
     }
+
+    func testTokenizeStringRedacted() throws {
+        let logContents = "SLF09#21%IDEActivityLogSection1@36\"Compile /Users/myuser/project/File.m"
+        let tokens = try lexer.tokenize(contents: logContents, redacted: true)
+        XCTAssertTrue(tokens.count == 4)
+        let stringToken = tokens[3]
+        XCTAssertEqual(stringToken, Token.string("Compile /Users/<redacted>/project/File.m"))
+    }
+
 }

--- a/docs/JSON Format.md
+++ b/docs/JSON Format.md
@@ -26,7 +26,8 @@ A typical step is parsed and output as JSON with the following format:
     "warningCount" : 0,
     "errors" : [],
     "warnings" : [],
-    "swiftFunctionTimes" : []
+    "swiftFunctionTimes" : [],
+    "fetchedFromCache" : false
 }
 ```
 
@@ -50,6 +51,7 @@ Other fields:
 - `errorCount`: the number of errors for the given step.
 - `errors`: the list of errors.
 - `swiftFunctionTimes`: Optional. If the step is a `swiftCompilation` and the app was compiled with the flags `-Xfrontend -debug-time-function-bodies` it will show the list of functions and their compilation time.
+- `fetchedFromCache`: For a `detail` step, `true` indicates that the file wasn't processed nor compiled but fetched from Xcode's internal cache. For a `main` or `target` step, `true` indicates that all its sub steps were fetched from cache, `false` that at least one sub step was proccesed or compiled.
 
 When possible, the `signature` content of `detail` steps is parsed to determine its type. This makes it easier to aggregate the data.
 


### PR DESCRIPTION
1. Faster redaction of User directory from logs. ~40% faster in my laptop
<img width="250" alt="Screenshot 2020-01-18 at 20 59 05" src="https://user-images.githubusercontent.com/22887/72728982-d7321580-3b8e-11ea-8647-be2f1377c3d4.png">

2. New property added to the parsed JSON: `fetchedFromCache`. With that property you can know which files were actually compiled and not fetched from Xcode's derived data. This is the same information shown in Xcode's own Report Navigator (thanks @polac24 for the heads up about that Xcode view)

Given a build when only one Swift Module (with 5 files) was compiled:

![image](https://user-images.githubusercontent.com/22887/72729550-aa323280-3b8f-11ea-849d-c2ef05114528.png)

The JSON will have only those 5 files with `fetchedFromCache` as `false`

![image](https://user-images.githubusercontent.com/22887/72729607-d352c300-3b8f-11ea-8c1a-2e6998f16f36.png)

I'm also showing the new property in the Detail page of a Build Step 

![image](https://user-images.githubusercontent.com/22887/72729773-4eb47480-3b90-11ea-83b3-9dd249ed93ff.png)


I plan to revamp the HTML report to show in an easier way the files that were actually compiled in a another PR.

cc @BalestraPatrick @polac24 

