### PR TITLE
Redacting home directory fix

### DIFF
--- a/Sources/XCLogParser/lexer/LexRedactor.swift
+++ b/Sources/XCLogParser/lexer/LexRedactor.swift
@@ -23,7 +23,7 @@ public class LexRedactor: LogRedactor {
     private static let redactedTemplate = "/Users/<redacted>/"
     private lazy var userDirRegex: NSRegularExpression? = {
         do {
-            return try NSRegularExpression(pattern: "\\/Users\\/(\\w*)\\/")
+            return try NSRegularExpression(pattern: "/Users/([^/]+)/")
         } catch {
             return nil
         }

--- a/Sources/XCLogParser/lexer/LexRedactor.swift
+++ b/Sources/XCLogParser/lexer/LexRedactor.swift
@@ -23,7 +23,7 @@ public class LexRedactor: LogRedactor {
     private static let redactedTemplate = "/Users/<redacted>/"
     private lazy var userDirRegex: NSRegularExpression? = {
         do {
-            return try NSRegularExpression(pattern: "/Users/([^/]+)/")
+            return try NSRegularExpression(pattern: "/Users/([^/]+)/?")
         } catch {
             return nil
         }

--- a/Tests/XCLogParserTests/LexRedactorTests.swift
+++ b/Tests/XCLogParserTests/LexRedactorTests.swift
@@ -36,8 +36,13 @@ class LexRedactorTests: XCTestCase {
         XCTAssertEqual(redactedText, "Some /Users/<redacted>/path")
     }
 
-    func testMultiplePathsRedacting() {
+    func testRedactingHomePath() {
+        let redactedText = redactor.redactUserDir(string: "/Users/private-user")
 
+        XCTAssertEqual(redactedText, "/Users/<redacted>/")
+    }
+
+    func testMultiplePathsRedacting() {
         let redactedText = redactor.redactUserDir(string: "Some /Users/private/path and other /Users/private/path2")
 
         XCTAssertEqual(redactedText, "Some /Users/<redacted>/path and other /Users/<redacted>/path2")

--- a/Tests/XCLogParserTests/LexRedactorTests.swift
+++ b/Tests/XCLogParserTests/LexRedactorTests.swift
@@ -69,5 +69,4 @@ class LexRedactorTests: XCTestCase {
 
         XCTAssertEqual(redactedText, "Some /Users/private/path")
     }
-    
 }

--- a/Tests/XCLogParserTests/LexRedactorTests.swift
+++ b/Tests/XCLogParserTests/LexRedactorTests.swift
@@ -25,8 +25,13 @@ class LexRedactorTests: XCTestCase {
     let redactor = LexRedactor()
 
     func testRedacting() {
-
         let redactedText = redactor.redactUserDir(string: "Some /Users/private/path")
+
+        XCTAssertEqual(redactedText, "Some /Users/<redacted>/path")
+    }
+
+    func testRedactingComplexUsername() {
+        let redactedText = redactor.redactUserDir(string: "Some /Users/private-user/path")
 
         XCTAssertEqual(redactedText, "Some /Users/<redacted>/path")
     }
@@ -59,4 +64,5 @@ class LexRedactorTests: XCTestCase {
 
         XCTAssertEqual(redactedText, "Some /Users/private/path")
     }
+    
 }


### PR DESCRIPTION
LexRedactor redacts home directories with non-words characters only (like `-`) and the home directory itself (not only a nested path).