### PR TITLE
Trigger CI job for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: swift
 branches:
   only:
   - master
+  - /^\d+\.\d+\.\d+.*$/
 cache:
   directories:
   - ".build"


### PR DESCRIPTION
Adds a ruby regex to trigger Travis build on tags with `1.2.3-optional-rc1` pattern.

[Travis docs](https://docs.travis-ci.com/user/customizing-the-build#using-regular-expressions)