### PR TITLE
Add compilation times to BuildStep and issues fixed

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.2"
+    public static let current = "0.2.4"
 
 }

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.1"
+    public static let current = "0.2.2"
 
 }

--- a/Sources/XCLogParser/loglocation/LogFinder.swift
+++ b/Sources/XCLogParser/loglocation/LogFinder.swift
@@ -54,7 +54,9 @@ public struct LogFinder {
         let projectDir = try getProjectDirWithLogOptions(logOptions)
 
         // get latestLog
+
         return try URL(fileURLWithPath: getLatestLogInDir(projectDir))
+
     }
 
     public func findLogManifestWithLogOptions(_ logOptions: LogOptions) throws -> URL {
@@ -106,6 +108,13 @@ public struct LogFinder {
 
     private func getProjectDir(withLogOptions logOptions: LogOptions,
                                andDerivedDataDir derivedData: URL) throws -> URL {
+        // when xcodebuild is run with -derivedDataPath the logs are at the root level
+        if logOptions.derivedDataPath.isEmpty == false {
+            if FileManager.default.fileExists(atPath:
+                derivedData.appendingPathComponent(logsDir).path) {
+                return derivedData.appendingPathComponent(logsDir)
+            }
+        }
         if logOptions.projectLocation.isEmpty == false {
             let folderName = try getProjectFolderWithHash(logOptions.projectLocation)
             return derivedData.appendingPathComponent(folderName)

--- a/Sources/XCLogParser/parser/BuildStep+Builder.swift
+++ b/Sources/XCLogParser/parser/BuildStep+Builder.swift
@@ -47,7 +47,10 @@ extension BuildStep {
                          errors: errors,
                          notes: notes,
                          swiftFunctionTimes: swiftFunctionTimes,
-                         fetchedFromCache: fetchedFromCache)
+                         fetchedFromCache: fetchedFromCache,
+                         compilationEndTimestamp: compilationEndTimestamp,
+                         compilationDuration: compilationDuration
+        )
     }
 
     func with(title newTitle: String) -> BuildStep {
@@ -76,7 +79,9 @@ extension BuildStep {
                          errors: errors,
                          notes: notes,
                          swiftFunctionTimes: swiftFunctionTimes,
-                         fetchedFromCache: fetchedFromCache)
+                         fetchedFromCache: fetchedFromCache,
+                         compilationEndTimestamp: compilationEndTimestamp,
+                         compilationDuration: compilationDuration)
     }
 
     func with(signature newSignature: String) -> BuildStep {
@@ -105,7 +110,9 @@ extension BuildStep {
                          errors: errors,
                          notes: notes,
                          swiftFunctionTimes: swiftFunctionTimes,
-                         fetchedFromCache: fetchedFromCache)
+                         fetchedFromCache: fetchedFromCache,
+                         compilationEndTimestamp: compilationEndTimestamp,
+                         compilationDuration: compilationDuration)
     }
 
     func withFilteredNotices() -> BuildStep {
@@ -137,7 +144,9 @@ extension BuildStep {
                          errors: filtereredErrors,
                          notes: filteredNotes,
                          swiftFunctionTimes: swiftFunctionTimes,
-                         fetchedFromCache: fetchedFromCache)
+                         fetchedFromCache: fetchedFromCache,
+                         compilationEndTimestamp: compilationEndTimestamp,
+                         compilationDuration: compilationDuration)
     }
 
     func with(subSteps newSubSteps: [BuildStep]) -> BuildStep {
@@ -166,7 +175,41 @@ extension BuildStep {
                          errors: errors,
                          notes: notes,
                          swiftFunctionTimes: swiftFunctionTimes,
-                         fetchedFromCache: fetchedFromCache)
+                         fetchedFromCache: fetchedFromCache,
+                         compilationEndTimestamp: compilationEndTimestamp,
+                         compilationDuration: compilationDuration)
+    }
+
+    func with(newCompilationEndTimestamp: Double,
+              andCompilationDuration newCompilationDuration: Double) -> BuildStep {
+        return BuildStep(type: type,
+                         machineName: machineName,
+                         buildIdentifier: buildIdentifier,
+                         identifier: identifier,
+                         parentIdentifier: parentIdentifier,
+                         domain: domain,
+                         title: title,
+                         signature: signature,
+                         startDate: startDate,
+                         endDate: endDate,
+                         startTimestamp: startTimestamp,
+                         endTimestamp: endTimestamp,
+                         duration: duration,
+                         detailStepType: detailStepType,
+                         buildStatus: buildStatus,
+                         schema: schema,
+                         subSteps: subSteps,
+                         warningCount: warningCount,
+                         errorCount: errorCount,
+                         architecture: architecture,
+                         documentURL: documentURL,
+                         warnings: warnings,
+                         errors: errors,
+                         notes: notes,
+                         swiftFunctionTimes: swiftFunctionTimes,
+                         fetchedFromCache: fetchedFromCache,
+                         compilationEndTimestamp: newCompilationEndTimestamp,
+                         compilationDuration: newCompilationDuration)
     }
 
     private func filterNotices(_ notices: [Notice]?) -> [Notice]? {

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -226,6 +226,15 @@ public struct BuildStep: Encodable {
     /// In a compilation step this will be false only if the file was actually compiled.
     /// in a `target` or `main` step it will be false if at least one sub step wasn't fetched from cache.
     public let fetchedFromCache: Bool
+
+    /// Actual compilation end time of the Step. With the new Build System, sometimes linking happens minutes
+    /// after compilation finishes. This is specially visible in Targets, where the files can be compiled
+    /// in seconds but the linking being done a couple of minutes after.
+    public var compilationEndTimestamp: Double
+
+    /// Actual compilation time of the Step. For Targets, this can be less than the `buildTime`
+    /// For steps that are't compilation steps such as `.scriptExecution` this will be 0
+    public var compilationDuration: Double
 }
 
 /// Extension used to flatten the three of a `BuildStep`
@@ -266,5 +275,13 @@ public extension BuildStep {
         var noSubSteps = self
         noSubSteps.subSteps = [BuildStep]()
         return noSubSteps
+    }
+
+    func isCompilationStep() -> Bool {
+        return detailStepType == .cCompilation
+        || detailStepType == .swiftCompilation
+        || detailStepType == .compileStoryboard
+        || detailStepType == .compileAssetsCatalog
+        || detailStepType == .swiftAggregatedCompilation
     }
 }

--- a/Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift
+++ b/Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift
@@ -117,8 +117,8 @@ extension IDEActivityLogSection {
     private func buildTargetSection(_ name: String, with section: IDEActivityLogSection) -> IDEActivityLogSection {
         return IDEActivityLogSection(sectionType: 2,
                                      domainType: section.domainType,
-                                     title: "Target \(name)",
-            signature: "",
+                                     title: "Build target \(name)",
+            signature: name,
             timeStartedRecording: section.timeStartedRecording,
             timeStoppedRecording: section.timeStoppedRecording,
             subSections: [IDEActivityLogSection](),

--- a/Tests/XCLogParserTests/BuildStep+TestUtils.swift
+++ b/Tests/XCLogParserTests/BuildStep+TestUtils.swift
@@ -1,0 +1,36 @@
+import Foundation
+@testable import XCLogParser
+
+func makeFakeBuildStep(title: String,
+                       type: BuildStepType,
+                       detailStepType: DetailStepType,
+                       startTimestamp: Double) -> BuildStep {
+    return BuildStep(type: type,
+                     machineName: "",
+                     buildIdentifier: "",
+                     identifier: "",
+                     parentIdentifier: "",
+                     domain: "",
+                     title: title,
+                     signature: "",
+                     startDate: "",
+                     endDate: "",
+                     startTimestamp: startTimestamp,
+                     endTimestamp: 0,
+                     duration: 0,
+                     detailStepType: detailStepType,
+                     buildStatus: "",
+                     schema: "",
+                     subSteps: [],
+                     warningCount: 0,
+                     errorCount: 0,
+                     architecture: "",
+                     documentURL: "",
+                     warnings: nil,
+                     errors: nil,
+                     notes: nil,
+                     swiftFunctionTimes: nil,
+                     fetchedFromCache: false,
+                     compilationEndTimestamp: 0,
+                     compilationDuration: 0)
+}

--- a/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
+++ b/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
@@ -78,7 +78,9 @@ class ChromeTracerOutputTests: XCTestCase {
                              errors: nil,
                              notes: nil,
                              swiftFunctionTimes: nil,
-                             fetchedFromCache: false
+                             fetchedFromCache: false,
+                             compilationEndTimestamp: end.timeIntervalSince1970,
+                             compilationDuration: 100 * 100
                              )
         return root
     }
@@ -111,7 +113,9 @@ class ChromeTracerOutputTests: XCTestCase {
                              errors: nil,
                              notes: nil,
                              swiftFunctionTimes: nil,
-                             fetchedFromCache: false
+                             fetchedFromCache: false,
+                             compilationEndTimestamp: end.timeIntervalSince1970,
+                             compilationDuration: 50 * 100
                              )
 
         let end2 = end.addingTimeInterval(50 * 100)
@@ -140,7 +144,9 @@ class ChromeTracerOutputTests: XCTestCase {
                                 errors: nil,
                                 notes: nil,
                                 swiftFunctionTimes: nil,
-                                fetchedFromCache: false
+                                fetchedFromCache: false,
+                                compilationEndTimestamp: end2.timeIntervalSince1970,
+                                compilationDuration: 50 * 100
                                 )
         return [target1, target2]
 

--- a/Tests/XCLogParserTests/LogFinderTests.swift
+++ b/Tests/XCLogParserTests/LogFinderTests.swift
@@ -144,4 +144,21 @@ class LogFinderTests: XCTestCase {
         XCTAssertThrowsError(try logFinder.findLogManifestWithLogOptions(logOptions))
     }
 
+    func testGetLogsFromCustomDerivedData() throws {
+        let customDerivedDataDir = try TestUtils.createRandomTestDir()
+        let logsFolder = customDerivedDataDir.appendingPathComponent("/Logs/Build", isDirectory: true)
+        _ = try TestUtils.createSubdir(logsFolder.path, in: customDerivedDataDir)
+        _ = try TestUtils.createSubdir(xcactivitylogName, in: logsFolder,
+                      attributes: [:])
+        let logOptions = LogOptions(projectName: "",
+                                    xcworkspacePath: "",
+                                    xcodeprojPath: "/tmp/MyApp.xcodeproj",
+                                    derivedDataPath: customDerivedDataDir.path,
+                                    logManifestPath: "")
+
+        let latestLog = try logFinder.findLatestLogWithLogOptions(logOptions)
+        XCTAssertTrue(latestLog.path.contains(xcactivitylogName),
+                      "latestLog \(latestLog) doesn't contains \(xcactivitylogName)")
+    }
+
 }

--- a/docs/JSON Format.md
+++ b/docs/JSON Format.md
@@ -27,7 +27,9 @@ A typical step is parsed and output as JSON with the following format:
     "errors" : [],
     "warnings" : [],
     "swiftFunctionTimes" : [],
-    "fetchedFromCache" : false
+    "fetchedFromCache" : false,
+    "compilationEndTimestamp": 1545143336.649699,
+    `compilationDuration`: 5.5941859483718872
 }
 ```
 
@@ -52,6 +54,8 @@ Other fields:
 - `errors`: the list of errors.
 - `swiftFunctionTimes`: Optional. If the step is a `swiftCompilation` and the app was compiled with the flags `-Xfrontend -debug-time-function-bodies` it will show the list of functions and their compilation time.
 - `fetchedFromCache`: For a `detail` step, `true` indicates that the file wasn't processed nor compiled but fetched from Xcode's internal cache. For a `main` or `target` step, `true` indicates that all its sub steps were fetched from cache, `false` that at least one sub step was proccesed or compiled.
+- `compilationEndTimestamp`: Timestamp in which the actual compilation finished. For a Target this could be before `endTimestamp` because in the new Xcode Build System linking can happen way after compilation.
+- `compilationDuration` Actual duration in seconds of just the compilation phase. In a Target this could be significant shorter than the `duration`.
 
 When possible, the `signature` content of `detail` steps is parsed to determine its type. This makes it easier to aggregate the data.
 

--- a/docs/JSON Format.md
+++ b/docs/JSON Format.md
@@ -29,7 +29,7 @@ A typical step is parsed and output as JSON with the following format:
     "swiftFunctionTimes" : [],
     "fetchedFromCache" : false,
     "compilationEndTimestamp": 1545143336.649699,
-    `compilationDuration`: 5.5941859483718872
+    "compilationDuration": 5.5941859483718872
 }
 ```
 


### PR DESCRIPTION
With the new Xcode's Build System, we've observed that the linking phase could happen a significant amount of time after the compilation phase. Because of this, by looking into the `duration` field of a target may be misleading, if you check the steps inside the target you could find that the compilation took a few seconds and the linking happened hundred of seconds later. 
This PR introduces two new fields: `compilationDuration` and `compilationEndTimestamp` that takes into account only the actual compilation time of a Target and an App. 

Also in this PR I fixed the issues https://github.com/spotify/XCLogParser/issues/51 and https://github.com/spotify/XCLogParser/issues/53