### PR TITLE
Add in support for --strictProjectName

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ An example output has been omitted for brevity since it can contain a lot of inf
   | Parameter Name | Description | Required |
   |-----|---|-----|
   | `--file`  | The path to the `xcactivitylog`.  | No * |
-  | `--project`  | The name of the project if you don't know the path to the log. The tool will try to find the latest Build log in a folder that starts with that name inside the `DerivedData` directory.  | No * |
+  | `--project`  | The name of the project if you don't know the path to the log. The tool will try to find the latest Build log in a folder that starts with that name inside the `DerivedData` directory.  Use `--strictProjectName` for stricter name matching.  | No * |
   | `--workspace`  | The path to the `xcworkspace` file if you don't know the path to the log. It will generate the folder name for the project in the `DerivedData` folder using Xcode's hash algorithm and it will try to locate the latest Build Log inside that directory.  | No * |
   | `--xcodeproj`  | The path to the `xcodeproj` file if you don't know the path to the log and if the project doesn't have a `xcworkspace` file. It will generate the folder name for the project in the `DerivedData` folder using Xcode's hash algorithm and it will try to locate the latest Build Log inside that directory.  | No * |
   | `--derived_data`  | The path to the derived data folder if you are using `xcodebuild` to build your project with the `-derivedDataPath` option.  | No |
   | `--output`  | If specified, the JSON file will be written to the given path. If not defined, the command will output to the standard output.  | No |
   | `--redacted`  | If specified, the username will be replaced by the word `redacted` in the file paths contained in the logs. Useful for privacy reasons but slightly decreases the performance.  | No |
+  | `--strictProjectName`  | Used in conjunction with `--project`. If specified, a stricter name matching will be done for the project name.  | No |
 
   >No *: One of `--file`, `--project`, `--workspace`, `--xcodeproj` parameters is required.
 
@@ -118,12 +119,13 @@ Example output available in the [reporters](#reporters) section.
   |-----|---|-----|
   | `--reporter`  | The reporter used to transform the logs. It can be either `json`, `flatJson`, `summaryJson`, `chromeTracer` or `html`. (required)  | Yes |
   | `--file`  | The path to the `xcactivitylog`.  | No * |
-  | `--project`  | The name of the project if you don't know the path to the log. The tool will try to find the latest Build log in a folder that starts with that name inside the `DerivedData` directory.  | No * |
+  | `--project`  | The name of the project if you don't know the path to the log. The tool will try to find the latest Build log in a folder that starts with that name inside the `DerivedData` directory.  Use `--strictProjectName` for stricter name matching.  | No * |
   | `--workspace`  | The path to the `xcworkspace` file if you don't know the path to the log. It will generate the folder name for the project in the `DerivedData` folder using Xcode's hash algorithm and it will try to locate the latest Build Log inside that directory.  | No * |
   | `--xcodeproj`  | The path to the `xcodeproj` file if you don't know the path to the log and if the project doesn't have a `xcworkspace` file. It will generate the folder name for the project in the `DerivedData` folder using Xcode's hash algorithm and it will try to locate the latest Build Log inside that directory.  | No * |
   | `--derived_data`  | The path to the derived data folder if you are using `xcodebuild` to build your project with the `-derivedDataPath` option.  | No |
   | `--output`  | If specified, the JSON file will be written to the given path. If not defined, the command will output to the standard output.  | No |
   | `--redacted`  | If specified, the username will be replaced by the word `redacted` in the file paths contained in the logs. Useful for privacy reasons but slightly decreases the performance.  | No |
+  | `--strictProjectName`  | Used in conjunction with `--project`. If specified, a stricter name matching will be done for the project name.  | No |
   | `--machine_name`  | If specified, the machine name will be used to create the `buildIdentifier`. If it is not specified, the host name will be used.  | No |
 
   >No *: One of `--file`, `--project`, `--workspace`, `--xcodeproj` parameters is required.
@@ -160,11 +162,12 @@ Example output:
   | Parameter Name | Description | Required |
   |-----|---|-----|
   | `--log_manifest`  | The path to an existing `LogStoreManifest.plist`.  | No * |
-  | `--project`  | The name of the project if you don't know the path to the log. The tool will try to find the latest Build log in a folder that starts with that name inside the `DerivedData` directory.  | No * |
+  | `--project`  | The name of the project if you don't know the path to the log. The tool will try to find the latest Build log in a folder that starts with that name inside the `DerivedData` directory.  Use `--strictProjectName` for stricter name matching.  | No * |
   | `--worskapce`  | The path to the `xcworkspace` file if you don't know the path to the log. It will generate the folder name for the project in the `DerivedData` folder using Xcode's hash algorithm and it will try to locate the latest Build Log inside that directory.  | No * |
   | `--xcodeproj`  | The path to the `xcodeproj` file if you don't know the path to the log and if the project doesn't have a `xcworkspace` file. It will generate the folder name for the project in the `DerivedData` folder using Xcode's hash algorithm and it will try to locate the latest Build Log inside that directory.  | No * |
   | `--derived_data`  | The path to the derived data folder if you are using `xcodebuild` to build your project with the `-derivedDataPath` option.  | No |
   | `--output`  | If specified, the JSON file will be written to the given path. If not defined, the command will output to the standard output.  | No |
+  | `--strictProjectName`  | Used in conjunction with `--project`. If specified, a stricter name matching will be done for the project name.  | No |
 
   >No *: One of `--log-manifest`, `--project`, `--workspace`, `--xcodeproj` parameters is required.
 

--- a/Sources/XCLogParser/commands/LogOptions.swift
+++ b/Sources/XCLogParser/commands/LogOptions.swift
@@ -39,6 +39,9 @@ public struct LogOptions {
     /// The path to a LogManifest.plist file
     let logManifestPath: String
 
+    /// Use strict Xcode project naming.
+    let strictProjectName: Bool
+    
     /// Computed property, return the xcworkspacePath if not empty or
     /// the xcodeprojPath if xcworkspacePath is empty
     var projectLocation: String {
@@ -49,26 +52,30 @@ public struct LogOptions {
                 xcworkspacePath: String,
                 xcodeprojPath: String,
                 derivedDataPath: String,
-                xcactivitylogPath: String) {
+                xcactivitylogPath: String,
+                strictProjectName: Bool = false) {
         self.projectName = projectName
         self.xcworkspacePath = xcworkspacePath
         self.xcodeprojPath = xcodeprojPath
         self.derivedDataPath = derivedDataPath
         self.xcactivitylogPath = xcactivitylogPath
         self.logManifestPath  = String()
+        self.strictProjectName = strictProjectName
     }
 
     public init(projectName: String,
                 xcworkspacePath: String,
                 xcodeprojPath: String,
                 derivedDataPath: String,
-                logManifestPath: String) {
+                logManifestPath: String,
+                strictProjectName: Bool = false) {
         self.projectName = projectName
         self.xcworkspacePath = xcworkspacePath
         self.xcodeprojPath = xcodeprojPath
         self.derivedDataPath = derivedDataPath
         self.logManifestPath = logManifestPath
         self.xcactivitylogPath = String()
+        self.strictProjectName = strictProjectName
     }
 
 }

--- a/Sources/XCLogParser/commands/LogOptions.swift
+++ b/Sources/XCLogParser/commands/LogOptions.swift
@@ -41,7 +41,7 @@ public struct LogOptions {
 
     /// Use strict Xcode project naming.
     let strictProjectName: Bool
-    
+
     /// Computed property, return the xcworkspacePath if not empty or
     /// the xcodeprojPath if xcworkspacePath is empty
     var projectLocation: String {

--- a/Sources/XCLogParser/loglocation/LogFinder.swift
+++ b/Sources/XCLogParser/loglocation/LogFinder.swift
@@ -173,9 +173,6 @@ public struct LogFinder {
                 }
                 return lhDate.compare(rhDate) == .orderedDescending
         }
-        for file in sorted {
-            print(file)
-        }
         guard let match = sorted.first else {
             throw LogError.xcodeBuildError("""
                 Error. There is no directory for the project \(name) in the DerivedData

--- a/Sources/XCLogParser/loglocation/LogFinder.swift
+++ b/Sources/XCLogParser/loglocation/LogFinder.swift
@@ -120,7 +120,9 @@ public struct LogFinder {
             return derivedData.appendingPathComponent(folderName)
         }
         if logOptions.projectName.isEmpty == false {
-            return try findDerivedDataForProject(logOptions.projectName, inDir: derivedData, strictProjectName: logOptions.strictProjectName)
+            return try findDerivedDataForProject(logOptions.projectName,
+                                                 inDir: derivedData,
+                                                 strictProjectName: logOptions.strictProjectName)
         }
         throw LogError.noLogFound(dir: derivedData.path)
     }
@@ -141,7 +143,9 @@ public struct LogFinder {
     /// - parameter name: Name of the project
     /// - parameter inDir: URL of the derived data directory
     /// - returns: The path to the derived data of the project or nil if it is not found.
-    public func findDerivedDataForProject(_ name: String, inDir derivedDataDir: URL, strictProjectName: Bool) throws -> URL {
+    public func findDerivedDataForProject(_ name: String,
+                                          inDir derivedDataDir: URL,
+                                          strictProjectName: Bool) throws -> URL {
 
         let fileManager = FileManager.default
 
@@ -156,7 +160,8 @@ public struct LogFinder {
                     return true
                 } else if let lastIndex = dirName.lastIndex(of: "-") {
                     // This looks for projectName-application_hash format
-                    // There are times when there are multiple directories of a given project with different application hashes
+                    // There are times when there are multiple directories
+                    // of a given project with different application hashes
                     dirName.removeSubrange(Range(uncheckedBounds: (lower: lastIndex, upper: dirName.endIndex)))
                     return dirName == name
                 }

--- a/Sources/XCLogParser/loglocation/LogFinder.swift
+++ b/Sources/XCLogParser/loglocation/LogFinder.swift
@@ -120,7 +120,7 @@ public struct LogFinder {
             return derivedData.appendingPathComponent(folderName)
         }
         if logOptions.projectName.isEmpty == false {
-            return try findDerivedDataForProject(logOptions.projectName, inDir: derivedData)
+            return try findDerivedDataForProject(logOptions.projectName, inDir: derivedData, strictProjectName: logOptions.strictProjectName)
         }
         throw LogError.noLogFound(dir: derivedData.path)
     }
@@ -141,7 +141,7 @@ public struct LogFinder {
     /// - parameter name: Name of the project
     /// - parameter inDir: URL of the derived data directory
     /// - returns: The path to the derived data of the project or nil if it is not found.
-    public func findDerivedDataForProject(_ name: String, inDir derivedDataDir: URL) throws -> URL {
+    public func findDerivedDataForProject(_ name: String, inDir derivedDataDir: URL, strictProjectName: Bool) throws -> URL {
 
         let fileManager = FileManager.default
 
@@ -149,6 +149,20 @@ public struct LogFinder {
                                                         includingPropertiesForKeys: [.contentModificationDateKey],
                                                         options: .skipsHiddenFiles)
         let sorted = try files.filter { url in
+            if strictProjectName {
+                var dirName = url.lastPathComponent
+                // Look for exact match first
+                if dirName == name {
+                    return true
+                } else if let lastIndex = dirName.lastIndex(of: "-") {
+                    // This looks for projectName-application_hash format
+                    // There are times when there are multiple directories of a given project with different application hashes
+                    dirName.removeSubrange(Range(uncheckedBounds: (lower: lastIndex, upper: dirName.endIndex)))
+                    return dirName == name
+                }
+                return false
+            }
+            // Fallback to default behavior
             let dirName = url.lastPathComponent.lowercased()
             return dirName.starts(with: name.lowercased())
             }.sorted {
@@ -158,6 +172,9 @@ public struct LogFinder {
                     return false
                 }
                 return lhDate.compare(rhDate) == .orderedDescending
+        }
+        for file in sorted {
+            print(file)
         }
         guard let match = sorted.first else {
             throw LogError.xcodeBuildError("""

--- a/Sources/XCLogParserApp/commands/CommonCommand.swift
+++ b/Sources/XCLogParserApp/commands/CommonCommand.swift
@@ -35,7 +35,8 @@ let projectOption = Option(
     key: "project",
     defaultValue: "",
     usage: "The name of an Xcode project. " +
-    "The tool will try to find the latest log folder with this prefix in the DerivedData directory.")
+    "The tool will try to find the latest log folder with this prefix in the DerivedData directory. " +
+    "Use with `--strictProjectName` for stricter name matching.")
 
 let workspaceOption = Option(
     key: "workspace",
@@ -53,6 +54,9 @@ let redactedSwitch = Switch(flag: "r",
                             key: "redacted",
                             usage: "Redacts the username of the paths found in the log. " +
     "For instance, /Users/timcook/project will be /Users/<redacted>/project")
+
+let strictProjectNameSwitch = Switch(key: "strictProjectName",
+                            usage: "Use strict name testing when trying to find the latest version of the project in the DerivedData directory.")
 
 let outputOption = Option(
     key: "output",

--- a/Sources/XCLogParserApp/commands/CommonCommand.swift
+++ b/Sources/XCLogParserApp/commands/CommonCommand.swift
@@ -56,7 +56,8 @@ let redactedSwitch = Switch(flag: "r",
     "For instance, /Users/timcook/project will be /Users/<redacted>/project")
 
 let strictProjectNameSwitch = Switch(key: "strictProjectName",
-                            usage: "Use strict name testing when trying to find the latest version of the project in the DerivedData directory.")
+    usage: "Use strict name testing when trying to find the latest version " +
+    "of the project in the DerivedData directory.")
 
 let outputOption = Option(
     key: "output",

--- a/Sources/XCLogParserApp/commands/DumpCommand.swift
+++ b/Sources/XCLogParserApp/commands/DumpCommand.swift
@@ -45,7 +45,8 @@ struct DumpCommand: CommandProtocol {
                                     xcworkspacePath: options.workspace,
                                     xcodeprojPath: options.xcodeproj,
                                     derivedDataPath: options.derivedData,
-                                    xcactivitylogPath: options.logFile)
+                                    xcactivitylogPath: options.logFile,
+                                    strictProjectName: options.strictProjectName)
         let actionOptions = ActionOptions(reporter: reporter,
                                            outputPath: options.output,
                                            redacted: options.redacted)
@@ -68,6 +69,7 @@ struct DumpOptions: OptionsProtocol {
     let workspace: String
     let xcodeproj: String
     let redacted: Bool
+    let strictProjectName: Bool
     let output: String
 
     static func create(_ logFile: String)
@@ -76,16 +78,18 @@ struct DumpOptions: OptionsProtocol {
         -> (_ workspace: String)
         -> (_ xcodeproj: String)
         -> (_ redacted: Bool)
+        -> (_ strictProjectName: Bool)
         -> (_ output: String) -> DumpOptions {
-            return { derivedData in { projectName in { workspace in { xcodeproj in { redacted in { output in
+            return { derivedData in { projectName in { workspace in { xcodeproj in { redacted in { strictProjectName in { output in
                     self.init(logFile: logFile,
                               derivedData: derivedData,
                               projectName: projectName,
                               workspace: workspace,
                               xcodeproj: xcodeproj,
                               redacted: redacted,
+                              strictProjectName: strictProjectName,
                               output: output)
-                }}}}}}
+                }}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<DumpOptions, CommandantError<CommandantError<Swift.Error>>> {
@@ -96,6 +100,7 @@ struct DumpOptions: OptionsProtocol {
             <*> mode <| workspaceOption
             <*> mode <| xcodeprojOption
             <*> mode <| redactedSwitch
+            <*> mode <| strictProjectNameSwitch
             <*> mode <| outputOption
     }
 

--- a/Sources/XCLogParserApp/commands/DumpCommand.swift
+++ b/Sources/XCLogParserApp/commands/DumpCommand.swift
@@ -80,7 +80,8 @@ struct DumpOptions: OptionsProtocol {
         -> (_ redacted: Bool)
         -> (_ strictProjectName: Bool)
         -> (_ output: String) -> DumpOptions {
-            return { derivedData in { projectName in { workspace in { xcodeproj in { redacted in { strictProjectName in { output in
+            return { derivedData in { projectName in { workspace in { xcodeproj in { redacted
+                in { strictProjectName in { output in
                     self.init(logFile: logFile,
                               derivedData: derivedData,
                               projectName: projectName,

--- a/Sources/XCLogParserApp/commands/ManifestCommand.swift
+++ b/Sources/XCLogParserApp/commands/ManifestCommand.swift
@@ -45,7 +45,8 @@ struct ManifestCommand: CommandProtocol {
                                     xcworkspacePath: options.workspace,
                                     xcodeprojPath: options.xcodeproj,
                                     derivedDataPath: options.derivedData,
-                                    logManifestPath: options.logManifest)
+                                    logManifestPath: options.logManifest,
+                                    strictProjectName: options.strictProjectName)
         let actionOptions = ActionOptions(reporter: reporter,
                                           outputPath: options.output,
                                           redacted: false)
@@ -69,6 +70,7 @@ struct ManifestOptions: OptionsProtocol {
     let xcodeproj: String
     let logManifest: String
     let output: String
+    let strictProjectName: Bool
 
     static func create(_ derivedData: String) ->
         (_ projectName: String) ->
@@ -76,16 +78,18 @@ struct ManifestOptions: OptionsProtocol {
         (_ xcodeproj: String) ->
         (_ logManifest: String) ->
         (_ output: String) ->
+        (_ strictProjectName: Bool) ->
         ManifestOptions {
-            return { projectName in { workspace in { xcodeproj in { logManifest in { output in
+            return { projectName in { workspace in { xcodeproj in { logManifest in { output in { strictProjectName in
                 self.init(derivedData: derivedData,
                           projectName: projectName,
                           workspace: workspace,
                           xcodeproj: xcodeproj,
                           logManifest: logManifest,
-                          output: output)
+                          output: output,
+                          strictProjectName: strictProjectName)
 
-                }}}}}
+                }}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<ManifestOptions,
@@ -102,6 +106,7 @@ struct ManifestOptions: OptionsProtocol {
                                    defaultValue: "",
                                    usage: "Optional. The path where to write the log entry.\n" +
                                    "If not specified, it will be writen to the Standard output")
+                <*> mode <| strictProjectNameSwitch
     }
 
     func isValid() -> Bool {

--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -56,7 +56,8 @@ struct ParseCommand: CommandProtocol {
                                     xcworkspacePath: options.workspace,
                                     xcodeprojPath: options.xcodeproj,
                                     derivedDataPath: options.derivedData,
-                                    xcactivitylogPath: options.logFile)
+                                    xcactivitylogPath: options.logFile,
+                                    strictProjectName: options.strictProjectName)
         let actionOptions = ActionOptions(reporter: reporter,
                                           outputPath: options.output,
                                           redacted: options.redacted,
@@ -82,6 +83,7 @@ struct ParseOptions: OptionsProtocol {
     let reporter: String
     let machineName: String
     let redacted: Bool
+    let strictProjectName: Bool
     let output: String
 
     static func create(_ logFile: String)
@@ -92,9 +94,10 @@ struct ParseOptions: OptionsProtocol {
         -> (_ reporter: String)
         -> (_ machineName: String)
         -> (_ redacted: Bool)
+        -> (_ strictProjectName: Bool)
         -> (_ output: String) -> ParseOptions {
             return { derivedData in { projectName in { workspace in { xcodeproj in { reporter in { machineName
-                in { redacted in {
+                in { redacted in { strictProjectName in {
             output in
             self.init(logFile: logFile,
                       derivedData: derivedData,
@@ -104,8 +107,9 @@ struct ParseOptions: OptionsProtocol {
                       reporter: reporter,
                       machineName: machineName,
                       redacted: redacted,
+                      strictProjectName: strictProjectName,
                       output: output)
-                }}}}}}}}
+                    }}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<ParseOptions, CommandantError<CommandantError<Swift.Error>>> {
@@ -126,6 +130,7 @@ struct ParseOptions: OptionsProtocol {
                 usage: "Optional. The name of the machine." +
                 "If not specified, the host name will be used.")
             <*> mode <| redactedSwitch
+            <*> mode <| strictProjectNameSwitch
             <*> mode <| outputOption
     }
 


### PR DESCRIPTION
Update for #64 

This will look for either an exact match or will try and match against a name in the directory after dropping the trailing `-XYZ`, where `XYZ` is the application hash.

This is done that way because I have seen projects have multiple application hashes. 
