### PR TITLE
Expose public steps initializers

### DIFF
--- a/Sources/XCLogParser/commands/ActionOptions.swift
+++ b/Sources/XCLogParser/commands/ActionOptions.swift
@@ -23,20 +23,20 @@ import Foundation
 public struct ActionOptions {
 
     /// The `Reporter` to use
-    let reporter: Reporter
+    public let reporter: Reporter
 
     /// The outputPath to write the report to.
     /// If empty, the report will be written to the StandardOutput
-    let outputPath: String
+    public let outputPath: String
 
     /// Used for actions involving the .xcactivitylog.
     /// If true, the username will be redacted from the paths in the log.
     /// Used to protect the privacy of the users.
-    let redacted: Bool
+    public let redacted: Bool
 
     /// Used in Parse actions. The current parsers use the host name to create a unique build identifier
     /// With this option, a user can override it and provide a name that will be used in that identifier.
-    let machineName: String?
+    public let machineName: String?
 
     public init(reporter: Reporter, outputPath: String, redacted: Bool, machineName: String? = nil) {
         self.reporter = reporter

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -235,6 +235,66 @@ public struct BuildStep: Encodable {
     /// Actual compilation time of the Step. For Targets, this can be less than the `buildTime`
     /// For steps that are't compilation steps such as `.scriptExecution` this will be 0
     public var compilationDuration: Double
+
+    /// Public initializer 
+    public init(type: BuildStepType,
+                machineName: String,
+                buildIdentifier: String,
+                identifier: String,
+                parentIdentifier: String,
+                domain: String,
+                title: String,
+                signature: String,
+                startDate: String,
+                endDate: String,
+                startTimestamp: Double,
+                endTimestamp: Double,
+                duration: Double,
+                detailStepType: DetailStepType,
+                buildStatus: String,
+                schema: String,
+                subSteps : [BuildStep],
+                warningCount: Int,
+                errorCount: Int,
+                architecture: String,
+                documentURL: String,
+                warnings: [Notice]?,
+                errors: [Notice]?,
+                notes: [Notice]?,
+                swiftFunctionTimes: [FunctionTime]?,
+                fetchedFromCache: Bool,
+                compilationEndTimestamp: Double,
+                compilationDuration: Double)
+    {
+        self.type = type
+        self.machineName = machineName
+        self.buildIdentifier = buildIdentifier
+        self.identifier = identifier
+        self.parentIdentifier = parentIdentifier
+        self.domain = domain
+        self.title = title
+        self.signature = signature
+        self.startDate = startDate
+        self.endDate = endDate
+        self.startTimestamp = startTimestamp
+        self.endTimestamp = endTimestamp
+        self.duration = duration
+        self.detailStepType = detailStepType
+        self.buildStatus = buildStatus
+        self.schema = schema
+        self.subSteps = subSteps
+        self.warningCount = warningCount
+        self.errorCount = errorCount
+        self.architecture = architecture
+        self.documentURL = documentURL
+        self.warnings = warnings
+        self.errors = errors
+        self.notes = notes
+        self.swiftFunctionTimes = swiftFunctionTimes
+        self.fetchedFromCache = fetchedFromCache
+        self.compilationEndTimestamp = compilationEndTimestamp
+        self.compilationDuration = compilationDuration
+    }
 }
 
 /// Extension used to flatten the three of a `BuildStep`

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -253,7 +253,7 @@ public struct BuildStep: Encodable {
                 detailStepType: DetailStepType,
                 buildStatus: String,
                 schema: String,
-                subSteps : [BuildStep],
+                subSteps: [BuildStep],
                 warningCount: Int,
                 errorCount: Int,
                 architecture: String,
@@ -264,8 +264,7 @@ public struct BuildStep: Encodable {
                 swiftFunctionTimes: [FunctionTime]?,
                 fetchedFromCache: Bool,
                 compilationEndTimestamp: Double,
-                compilationDuration: Double)
-    {
+                compilationDuration: Double) {
         self.type = type
         self.machineName = machineName
         self.buildIdentifier = buildIdentifier

--- a/Sources/XCLogParser/parser/Notice.swift
+++ b/Sources/XCLogParser/parser/Notice.swift
@@ -98,6 +98,33 @@ public class Notice: Encodable {
         return NSRegularExpression.fromPattern(pattern)
     }()
 
+    /// Public initializer 
+    public init(type: NoticeType,
+                title: String,
+                clangFlag: String?,
+                documentURL: String,
+                severity: Int,
+                startingLineNumber: UInt64,
+                endingLineNumber: UInt64,
+                startingColumnNumber: UInt64,
+                endingColumnNumber: UInt64,
+                characterRangeEnd: UInt64,
+                characterRangeStart: UInt64,
+                interfaceBuilderIdentifier: String?) {
+        self.type = type
+        self.title = title
+        self.clangFlag = clangFlag
+        self.documentURL = documentURL
+        self.severity = severity
+        self.startingLineNumber = startingLineNumber
+        self.endingLineNumber = endingLineNumber
+        self.startingColumnNumber = startingColumnNumber
+        self.endingColumnNumber = endingColumnNumber
+        self.characterRangeEnd = characterRangeEnd
+        self.characterRangeStart = characterRangeStart
+        self.interfaceBuilderIdentifier = interfaceBuilderIdentifier
+    }
+
     public init?(withType type: NoticeType?,
                  logMessage: IDEActivityLogMessage,
                  andClangFlag clangFlag: String? = nil) {


### PR DESCRIPTION
Struct memberwise initializers are by default internal. Introducing explicit public initailizers to use outside of XCLogParser. 

> Default Memberwise Initializers for Structure Types
> As with the default initializer above, if you want a public structure type to be initializable with a memberwise initializer when used in another module, you must provide a public memberwise initializer yourself as part of the type’s definition.

It exposes also ActionOptions properties, as requested in #63