### PR TITLE
Fix compilationEndDate for noop builds 

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.7"
+    public static let current = "0.2.8"
 
 }

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -322,11 +322,12 @@ public final class ParserBuildSteps {
     }
 
     private func addCompilationTimesToTarget(_ target: BuildStep) -> BuildStep {
+
         let lastCompilationStep = target.subSteps
             .filter { $0.isCompilationStep() && $0.fetchedFromCache == false }
             .max { $0.compilationEndTimestamp < $1.compilationEndTimestamp }
         guard let lastStep = lastCompilationStep else {
-            return target
+            return target.with(newCompilationEndTimestamp: target.startTimestamp, andCompilationDuration: 0.0)
         }
         return target.with(newCompilationEndTimestamp: lastStep.compilationEndTimestamp,
                          andCompilationDuration: lastStep.compilationEndTimestamp - target.startTimestamp)
@@ -334,10 +335,11 @@ public final class ParserBuildSteps {
 
     private func addCompilationTimesToApp(_ app: BuildStep) -> BuildStep {
         let lastCompilationStep = app.subSteps
-            .filter { $0.compilationEndTimestamp > 0 && $0.fetchedFromCache == false }
+            .filter { $0.compilationDuration > 0 && $0.fetchedFromCache == false }
             .max { $0.compilationEndTimestamp < $1.compilationEndTimestamp }
         guard let lastStep = lastCompilationStep else {
-            return app
+            return app.with(newCompilationEndTimestamp: app.startTimestamp,
+                            andCompilationDuration: 0.0)
         }
         return app.with(newCompilationEndTimestamp: lastStep.compilationEndTimestamp,
                          andCompilationDuration: lastStep.compilationEndTimestamp - app.startTimestamp)

--- a/Tests/XCLogParserTests/BuildStep+TestUtils.swift
+++ b/Tests/XCLogParserTests/BuildStep+TestUtils.swift
@@ -4,7 +4,8 @@ import Foundation
 func makeFakeBuildStep(title: String,
                        type: BuildStepType,
                        detailStepType: DetailStepType,
-                       startTimestamp: Double) -> BuildStep {
+                       startTimestamp: Double,
+                       fetchedFromCache: Bool) -> BuildStep {
     return BuildStep(type: type,
                      machineName: "",
                      buildIdentifier: "",
@@ -30,7 +31,7 @@ func makeFakeBuildStep(title: String,
                      errors: nil,
                      notes: nil,
                      swiftFunctionTimes: nil,
-                     fetchedFromCache: false,
+                     fetchedFromCache: fetchedFromCache,
                      compilationEndTimestamp: 0,
                      compilationDuration: 0)
 }


### PR DESCRIPTION
Builds that didn't compile any file, should have a compilation end date that is equal to its start date. Currently they show an empty timestamp that is equal to Jan 1 1970.