### PR TITLE
Fix parsing warnings and errors in the same file bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM swift:5.1
-RUN apt-get update && apt-get install -y zlib1g-dev
+RUN apt-get update && apt-get install -y zlib1g-dev ruby
 CMD cd xclogparser && swift build

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The Finder will automatically open the output folder after a build completes and
     # The following arguments are directly forwarded to the executable.
     # We execute the command in the background and immediately close the input, output
     # and error streams in order to let Xcode and xcodebuild finish cleanly.
-    # This is done to prevent Xcode and xcodebuild being stuck in waiting for all 
+    # This is done to prevent Xcode and xcodebuild being stuck in waiting for all
     # subprocesses to end before exiting.
     executable=$1
     shift;
@@ -447,6 +447,7 @@ xclogparser parse --file path/to/log.xcactivitylog --reporter issues
 
 <details>
     <summary>Example Output</summary>
+
     ```json
     {
       "errors" : [

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.12"
+    public static let current = "0.2.13"
 
 }

--- a/Tests/XCLogParserTests/XCTestManifests.swift
+++ b/Tests/XCLogParserTests/XCTestManifests.swift
@@ -106,7 +106,7 @@ extension ParserTests {
         ("testParseNote", testParseNote),
         ("testParseTargetCompilationTimes", testParseTargetCompilationTimes),
         ("testParseTargetName", testParseTargetName),
-        ("testParseWarning", testParseWarning),
+        ("testParseWarningsAndErrors", testParseWarningsAndErrors),
     ]
 }
 


### PR DESCRIPTION
If a file has both clang warnings and errors, the parser was only reporting the warnings.

cc @BalestraPatrick @polac24 