### PR TITLE
Handle more error types and parse Swift error/warnings details

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.13"
+    public static let current = "0.2.14"
 
 }

--- a/Sources/XCLogParser/extensions/ArrayExtension.swift
+++ b/Sources/XCLogParser/extensions/ArrayExtension.swift
@@ -38,7 +38,8 @@ extension Array where Element: Notice {
             $0.type == .clangWarning ||
             $0.type == .projectWarning ||
             $0.type == .analyzerWarning ||
-            $0.type == .interfaceBuilderWarning
+            $0.type == .interfaceBuilderWarning ||
+            $0.type == .deprecatedWarning
         }
     }
 

--- a/Sources/XCLogParser/parser/Notice.swift
+++ b/Sources/XCLogParser/parser/Notice.swift
@@ -280,7 +280,7 @@ public class Notice: Codable {
         }
     }
 
-    /// Xcode reportes the details of Swift errors and warnings as a mixed text with all the errors in a
+    /// Xcode reports the details of Swift errors and warnings as a mixed text with all the errors in a
     /// compilation unit in the same Text. This functions parses.
     /// - parameter text: The LogSection.text with the error details
     /// - returns: A Dictionary where the keys are the error location in the form pathToFile:line:column:

--- a/Tests/XCLogParserTests/XCTestManifests.swift
+++ b/Tests/XCLogParserTests/XCTestManifests.swift
@@ -104,6 +104,7 @@ extension ParserTests {
         ("testParseAppNoopCompilationTimes", testParseAppNoopCompilationTimes),
         ("testParseInterfaceBuilderWarning", testParseInterfaceBuilderWarning),
         ("testParseNote", testParseNote),
+        ("testParseSwiftIssuesDetails", testParseSwiftIssuesDetails),
         ("testParseTargetCompilationTimes", testParseTargetCompilationTimes),
         ("testParseTargetName", testParseTargetName),
         ("testParseWarningsAndErrors", testParseWarningsAndErrors),


### PR DESCRIPTION
I've been reproducing more error types in Xcode and then try to parse them with XCLogParser. This PRs adds those that weren't categorised as Errors or Warnings.

I also just noted that the line and column numbers that Xcode reports are zero-based, so I'm adding 1 to them to have an accurate number. 

I'm introducing a new kind of warning: `deprecatedWarning` to mark Clang and Swiftc deprecation issues. Handy if you want to track deprecations in your project and inform the users about them.

Finally, there was a long standing bug: Swiftc reports the error/warning details of a file in a single String. I'm parsing that large string and attribute each detail to the right error/warning. 

cc @alrocha @BalestraPatrick @polac24 