### PR TITLE
Handle clangWarnings as errors, handle script and linker errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -113,7 +113,7 @@ end
 
 def get_version
   version_file = File.open('Sources/XCLogParser/commands/Version.swift').read
-  /let current = "(?<version>[\d.]*)"/ =~ version_file
+  /let current = \"(?<version>.*)\"/ =~ version_file
   version
 end
 

--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -279,7 +279,7 @@ public class ActivityParser {
         if className == String(describing: DVTTextDocumentLocation.self) {
             return try parseDVTTextDocumentLocation(iterator: &iterator)
         } else if className == String(describing: DVTDocumentLocation.self)  ||
-            className == "Xcode3ProjectDocumentLocation" {
+            className == "Xcode3ProjectDocumentLocation" || className == "IDELogDocumentLocation" {
             return try parseDVTDocumentLocation(iterator: &iterator)
         } else if className == String(describing: IBDocumentMemberLocation.self) {
             return try parseIBDocumentMemberLocation(iterator: &iterator)

--- a/Sources/XCLogParser/extensions/ArrayExtension.swift
+++ b/Sources/XCLogParser/extensions/ArrayExtension.swift
@@ -45,7 +45,12 @@ extension Array where Element: Notice {
 
     func getErrors() -> [Notice] {
         return filter {
-            $0.type == .swiftError || $0.type == .error || $0.type == .clangError
+            $0.type == .swiftError ||
+            $0.type == .error ||
+            $0.type == .clangError ||
+            $0.type == .linkerError ||
+            $0.type == .packageLoadingError ||
+            $0.type == .scriptPhaseError
         }
     }
 

--- a/Sources/XCLogParser/parser/Contains.swift
+++ b/Sources/XCLogParser/parser/Contains.swift
@@ -19,8 +19,21 @@
 
 import Foundation
 
-public struct Version {
+public struct Contains {
 
-    public static let current = "0.2.15"
+    let str: String
 
+    public init(_ str: String) {
+        self.str = str.lowercased()
+    }
+
+    private func match(_ input: String) -> Bool {
+        return input.lowercased().contains(str)
+    }
+}
+
+extension Contains {
+    static func ~= (contains: Contains, input: String) -> Bool {
+        return contains.match(input)
+    }
 }

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -36,7 +36,7 @@ extension Notice {
             clangWarningsFlags.count > 0 {
             clangWarnings = zip(logSection.messages, clangWarningsFlags)
                 .compactMap { (message, warningFlag) -> Notice? in
-                    // If the warning is treated as error, we marked the issue as errro
+                    // If the warning is treated as error, we marked the issue as error
                     let type: NoticeType = warningFlag.contains("-Werror") ? .clangError : .clangWarning
                     return Notice(withType: type, logMessage: message, clangFlag: warningFlag)
             }

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -1,0 +1,160 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+/// Functions to parser Notices from `IDELogSection` and `IDELogMessage`
+extension Notice {
+
+    /// Parses an `IDEActivityLogSection` looking for Warnings, Errors and Notes in its `IDEActivityLogMessage`.
+    /// Uses the `categoryIdent` of `IDEActivityLogMessage` to categorize them.
+    /// For CLANG warnings, it parses the `IDEActivityLogSection` text property looking for a *-W-warning-name* pattern
+    /// - parameter logSection: An `IDEActivityLogSection`
+    /// - parameter forType: The `DetailStepType` of the logSection
+    /// - returns: An Array of `Notice`
+    public static func parseFromLogSection(_ logSection: IDEActivityLogSection, forType type: DetailStepType)
+        -> [Notice] {
+        // we look for clangWarnings parsing the text of the logSection
+        var clangWarnings: [Notice] = []
+        if let clangWarningsFlags = self.parseClangWarningFlags(text: logSection.text),
+            clangWarningsFlags.count > 0 {
+            clangWarnings = zip(logSection.messages, clangWarningsFlags)
+                .compactMap { (message, warningFlag) -> Notice? in
+                    // If the warning is treated as error, we marked the issue as errro
+                    let type: NoticeType = warningFlag.contains("-Werror") ? .clangError : .clangWarning
+                    return Notice(withType: type, logMessage: message, clangFlag: warningFlag)
+            }
+        }
+        // Remove the messages that were categorized as clangWarnings
+        let remainingLogMessages = logSection.messages.filter { message in
+            return clangWarnings.contains { $0.title == message.title } == false
+        }
+        // parse details for Swift issues
+        let swiftErrorDetails = parseSwiftIssuesDetailsByLocation(logSection.text)
+        // we look for analyzer warnings, swift warnings, notes and errors
+        return clangWarnings + remainingLogMessages.compactMap { message -> [Notice]? in
+            if let resultMessage = message as? IDEActivityLogAnalyzerResultMessage {
+                return resultMessage.subMessages.compactMap {
+                    if let stepMessage = $0 as? IDEActivityLogAnalyzerEventStepMessage {
+                        return Notice(withType: .analyzerWarning, logMessage: stepMessage)
+                    }
+                    return nil
+                }
+            }
+            // Special case, Interface builder warning can only be spotted by checking the whole text of the
+            // log section
+            let noticeTypeTitle = message.categoryIdent.isEmpty ? logSection.text : message.categoryIdent
+            if var notice = Notice(withType: NoticeType.fromTitle(noticeTypeTitle),
+                                   logMessage: message,
+                                   detail: logSection.text) {
+
+                // Add the right details to Swift errors
+                if notice.type == NoticeType.swiftError || notice.type == .swiftWarning {
+                    var errorLocation = notice.documentURL.replacingOccurrences(of: "file://", with: "")
+                    errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
+
+                    notice = notice.with(detail: swiftErrorDetails[errorLocation])
+                }
+
+                // Handle special cases
+
+                // Xcode reports swift deprecation warnings as swift errors, mark them as deprecatedWarnings
+                if isDeprecatedWarning(type: notice.type, text: notice.title) {
+                    return [notice.with(type: .deprecatedWarning)]
+                }
+                // Ld command errors
+                if notice.type == .error && type == .linker {
+                    return [notice.with(type: .linkerError)]
+                }
+                // Build phase's script errors
+                if notice.type == .scriptPhaseError {
+                    // Decorate script phase error with the signature that contains the name of the
+                    // phase and the target
+                    return [notice.with(detail: "\(notice.detail ?? "") \(logSection.signature)")]
+                }
+                return [notice]
+            }
+            return nil
+        }.reduce([Notice]()) { flatten, notices -> [Notice] in
+            flatten + notices
+        }
+    }
+
+    /// Xcode reports the details of Swift errors and warnings as a mixed text with all the errors in a
+    /// compilation unit in the same Text. This functions parses.
+    /// - parameter text: The LogSection.text with the error details
+    /// - returns: A Dictionary where the keys are the error location in the form pathToFile:line:column:
+    /// and the values are the error details for that location
+    public static func parseSwiftIssuesDetailsByLocation(_ text: String) -> [String: String] {
+        return text
+            .split(separator: "\r")
+            .reduce([]) { (details, line) -> [String] in
+                var details = details
+                if line.contains(": error:") || line.contains(": warning:") {
+                    details.append(String(line))
+                } else {
+                    guard let current = details.last else {
+                        return details
+                    }
+                    details.removeLast()
+                    details.append("\(current)\n\(line)")
+                }
+                return details
+        }
+        .reduce([String: String]()) { (detailsByLoc, detail) -> [String: String] in
+            let range: Range<String.Index>?
+            if detail.contains(": error:") {
+                range = detail.range(of: ": error:")
+            } else {
+                range = detail.range(of: ": warning:")
+            }
+            if let range = range {
+                let location = detail[...range.lowerBound]
+                var detailsByLoc = detailsByLoc
+                detailsByLoc[String(location)] = detail
+                return detailsByLoc
+            }
+            return detailsByLoc
+        }
+    }
+
+    /// Parses the text of a IDELogSection looking for the pattern [-Wwarning-type]
+    /// that means there was a clang warning.
+    /// - parameter text: IDELogSection text property
+    /// - returns: A list of clang warning flags found in the text, like -Wunused-function
+    private static func parseClangWarningFlags(text: String) -> [String]? {
+        guard let clangWarningRegexp = Notice.clangWarningRegexp else {
+            return nil
+        }
+        let range = NSRange(location: 0, length: text.count)
+        let matches = clangWarningRegexp.matches(in: text, options: .reportCompletion, range: range)
+        return matches.map { result -> String in
+            String(text.substring(result.range))
+        }
+    }
+
+    private static func isDeprecatedWarning(type: NoticeType, text: String) -> Bool {
+        if type == .swiftError || type == .swiftWarning || type == .projectWarning || type == .clangWarning {
+            return text.contains(" deprecated:")
+                || text.contains("was deprecated in")
+                || text.contains("has been deprecated")
+        }
+        return false
+    }
+}

--- a/Sources/XCLogParser/parser/Notice.swift
+++ b/Sources/XCLogParser/parser/Notice.swift
@@ -19,75 +19,6 @@
 
 import Foundation
 
-/// The type of a Notice
-public enum NoticeType: String, Codable {
-
-    /// Notes
-    case note
-
-    /// A warning thrown by the Swift compiler
-    case swiftWarning
-
-    /// A warning thrown by the C compiler
-    case clangWarning
-
-    /// A warning at a project level. For instance:
-    /// "Warning Swift 3 mode has been deprecated and will be removed in a later version of Xcode"
-    case projectWarning
-
-    /// An error in a non-compilation step. For instance creating a directory or running a shell script phase
-    case error
-
-    /// An error thrown by the Swift compiler
-    case swiftError
-
-    /// An error thrown by the C compiler
-    case clangError
-
-    /// A warning returned by Xcode static analyzer
-    case analyzerWarning
-
-    /// A warning inside an Interface Builder file
-    case interfaceBuilderWarning
-
-    /// A warning about the usage of a deprecated API
-    case deprecatedWarning
-
-    // swiftlint:disable:next cyclomatic_complexity
-    public static func fromTitle(_ title: String) -> NoticeType? {
-        switch title {
-        case "Swift Compiler Warning":
-            return .swiftWarning
-        case "Notice":
-            return .note
-        case "Swift Compiler Error":
-            return .swiftError
-        case Prefix("Lexical"):
-            return .clangError
-        case Suffix("Semantic Issue"):
-            return .clangError
-        case Suffix("Deprecations"):
-            return .deprecatedWarning
-        case "Warning":
-            return .projectWarning
-        case "Apple Mach-O Linker Warning":
-            return .projectWarning
-        case Suffix("Error"):
-            return .error
-        case Suffix("Notice"):
-            return .note
-        case Prefix("/* com.apple.ibtool.document.warnings */"):
-            return .interfaceBuilderWarning
-        case "Parse Issue":
-            return .clangError
-        case "Uncategorized":
-            return .clangError
-        default:
-            return .note
-        }
-    }
-}
-
 /// Xcode reports warnings, errors and notes as IDEActivityLogMessage. This class
 /// wraps that data
 public class Notice: Codable {
@@ -107,7 +38,7 @@ public class Notice: Codable {
     public let detail: String?
 
     static var clangWarningRegexp: NSRegularExpression? = {
-        let pattern = "\\[(-W[\\w-]*)\\]+"
+        let pattern = "\\[(-W[\\w-,]*)\\]+"
         return NSRegularExpression.fromPattern(pattern)
     }()
 
@@ -221,118 +152,6 @@ public class Notice: Codable {
                       detail: detail)
     }
 
-    /// Parses an `IDEActivityLogSection` looking for Warnings, Errors and Notes in its `IDEActivityLogMessage`.
-    /// Uses the `categoryIdent` of `IDEActivityLogMessage` to categorize them.
-    /// For CLANG warnings, it parses the `IDEActivityLogSection` text property looking for a *-W-warning-name* pattern
-    /// - parameter logSection: An `IDEActivityLogSection`
-    /// - returns: An Array of `Notice`
-    public static func parseFromLogSection(_ logSection: IDEActivityLogSection) -> [Notice] {
-        // we look for clangWarnings parsing the text of the logSection
-        var clangWarnings: [Notice] = []
-        if let clangWarningsFlags = self.parseClangWarningFlags(text: logSection.text),
-            clangWarningsFlags.count > 0 {
-            clangWarnings = zip(logSection.messages, clangWarningsFlags)
-                .compactMap { (message, warningFlag) -> Notice? in
-                Notice(withType: .clangWarning, logMessage: message, clangFlag: warningFlag)
-            }
-        }
-        // Remove the messages that were categorized as clangWarnings
-        let remainingLogMessages = logSection.messages.filter { message in
-            return clangWarnings.contains { $0.title == message.title } == false
-        }
-        // parse details for Swift issues
-        let swiftErrorDetails = parseSwiftIssuesDetailsByLocation(logSection.text)
-        // we look for analyzer warnings, swift warnings, notes and errors
-        return clangWarnings + remainingLogMessages.compactMap { message -> [Notice]? in
-            if let resultMessage = message as? IDEActivityLogAnalyzerResultMessage {
-                return resultMessage.subMessages.compactMap {
-                    if let stepMessage = $0 as? IDEActivityLogAnalyzerEventStepMessage {
-                        return Notice(withType: .analyzerWarning, logMessage: stepMessage)
-                    }
-                    return nil
-                }
-            }
-            // Special case, Interface builder warning can only be spotted by checking the whole text of the
-            // log section
-            let noticeTypeTitle = message.categoryIdent.isEmpty ? logSection.text : message.categoryIdent
-
-            if var notice = Notice(withType: NoticeType.fromTitle(noticeTypeTitle),
-                                   logMessage: message,
-                                   detail: logSection.text) {
-
-                // Add the right details to Swift errors
-                if notice.type == NoticeType.swiftError {
-                    var errorLocation = notice.documentURL.replacingOccurrences(of: "file://", with: "")
-                    errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
-
-                    notice = notice.with(detail: swiftErrorDetails[errorLocation])
-                }
-
-                // Xcode reports swift deprecation warnings as errors, fix it
-                if notice.type == NoticeType.swiftError && notice.title.contains(" deprecated:") {
-                    notice = notice.with(type: .deprecatedWarning)
-                }
-                return [notice]
-            }
-            return nil
-        }.reduce([Notice]()) { flatten, notices -> [Notice] in
-            flatten + notices
-        }
-    }
-
-    /// Xcode reports the details of Swift errors and warnings as a mixed text with all the errors in a
-    /// compilation unit in the same Text. This functions parses.
-    /// - parameter text: The LogSection.text with the error details
-    /// - returns: A Dictionary where the keys are the error location in the form pathToFile:line:column:
-    /// and the values are the error details for that location
-    public static func parseSwiftIssuesDetailsByLocation(_ text: String) -> [String: String] {
-        return text
-            .split(separator: "\r")
-            .reduce([]) { (details, line) -> [String] in
-                var details = details
-                if line.contains(": error:") || line.contains(": warning:") {
-                    details.append(String(line))
-                } else {
-                    guard let current = details.last else {
-                        return details
-                    }
-                    details.removeLast()
-                    details.append("\(current)\n\(line)")
-                }
-                return details
-            }
-            .reduce([String: String]()) { (detailsByLoc, detail) -> [String: String] in
-                let range: Range<String.Index>?
-                if detail.contains(": error:") {
-                    range = detail.range(of: ": error:")
-                } else {
-                    range = detail.range(of: ": warning:")
-                }
-                if let range = range {
-                    let location = detail[...range.lowerBound]
-                    var detailsByLoc = detailsByLoc
-                    detailsByLoc[String(location)] = detail
-                    return detailsByLoc
-                }
-                return detailsByLoc
-            }
-    }
-
-    /// Parses the text of a IDELogSection looking for the pattern [-Wwarning-type]
-    /// that means there was a clang warning.
-    /// - parameter text: IDELogSection text property
-    /// - returns: A list of clang warning flags found in the text, like -Wunused-function
-    private static func parseClangWarningFlags(text: String) -> [String]? {
-        guard let clangWarningRegexp = Notice.clangWarningRegexp else {
-            return nil
-        }
-        let range = NSRange(location: 0, length: text.count)
-        let matches = clangWarningRegexp.matches(in: text, options: .reportCompletion, range: range)
-        return matches.map { result -> String in
-            String(text.substring(result.range))
-        }
-    }
-
     /// Xcode reports the line and column number based on a zero-index location
     /// This adds a 1 to report the real location
     /// If there is no location, Xcode reports UIInt64.max. In that case this function
@@ -343,5 +162,4 @@ public class Notice: Codable {
         }
         return number
     }
-
 }

--- a/Sources/XCLogParser/parser/NoticeType.swift
+++ b/Sources/XCLogParser/parser/NoticeType.swift
@@ -1,0 +1,94 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+/// The type of a Notice
+public enum NoticeType: String, Codable {
+
+    /// Notes
+    case note
+
+    /// A warning thrown by the Swift compiler
+    case swiftWarning
+
+    /// A warning thrown by the C compiler
+    case clangWarning
+
+    /// A warning at a project level. For instance:
+    /// "Warning Swift 3 mode has been deprecated and will be removed in a later version of Xcode"
+    case projectWarning
+
+    /// An error in a non-compilation step. For instance creating a directory or running a shell script phase
+    case error
+
+    /// An error thrown by the Swift compiler
+    case swiftError
+
+    /// An error thrown by the C compiler
+    case clangError
+
+    /// A warning returned by Xcode static analyzer
+    case analyzerWarning
+
+    /// A warning inside an Interface Builder file
+    case interfaceBuilderWarning
+
+    /// A warning about the usage of a deprecated API
+    case deprecatedWarning
+
+    /// Error thrown by the Linker
+    case linkerError
+
+    /// Error loading Swift Packages
+    case packageLoadingError
+
+    /// Error running a Build Phase's script
+    case scriptPhaseError
+
+    // swiftlint:disable:next cyclomatic_complexity
+    public static func fromTitle(_ title: String) -> NoticeType? {
+        switch title {
+        case "Swift Compiler Warning":
+            return .swiftWarning
+        case "Notice":
+            return .note
+        case "Swift Compiler Error":
+            return .swiftError
+        case Prefix("Lexical"), Suffix("Semantic Issue"), "Parse Issue", "Uncategorized":
+            return .clangError
+        case Suffix("Deprecations"):
+            return .deprecatedWarning
+        case "Warning", "Apple Mach-O Linker Warning", "Target Integrity":
+            return .projectWarning
+        case Suffix("Error"):
+            return .error
+        case Suffix("Notice"):
+            return .note
+        case Prefix("/* com.apple.ibtool.document.warnings */"):
+            return .interfaceBuilderWarning
+        case "Package Loading":
+            return .packageLoadingError
+        case Contains("Command PhaseScriptExecution"):
+            return .scriptPhaseError
+        default:
+            return .note
+        }
+    }
+}

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -109,7 +109,7 @@ public final class ParserBuildSteps {
                 targetErrors = 0
                 targetWarnings = 0
             }
-            let notices = parseWarningsAndErrorsFromLogSection(logSection)
+            let notices = parseWarningsAndErrorsFromLogSection(logSection, forType: detailType)
             let warnings: [Notice]? = notices?["warnings"]
             let errors: [Notice]? = notices?["errors"]
             let notes: [Notice]? = notices?["notes"]
@@ -269,8 +269,9 @@ public final class ParserBuildSteps {
         return command.substring(match.range(at: 1))
     }
 
-    private func parseWarningsAndErrorsFromLogSection(_ logSection: IDEActivityLogSection) -> [String: [Notice]]? {
-        let notices = Notice.parseFromLogSection(logSection)
+    private func parseWarningsAndErrorsFromLogSection(_ logSection: IDEActivityLogSection, forType type: DetailStepType)
+        -> [String: [Notice]]? {
+        let notices = Notice.parseFromLogSection(logSection, forType: type)
         return ["warnings": notices.getWarnings(),
                 "errors": notices.getErrors(),
                 "notes": notices.getNotes()]


### PR DESCRIPTION
I added more error type's categorisation. I also moved the parsing logic out to its own extension.

cc @alrocha @BalestraPatrick @polac24 