### PR TITLE
Add support for Xcode12 beta and Clang deprecation warnings

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -295,7 +295,8 @@ public class ActivityParser {
             throw XCLogParserError.parseError("Unexpected token found parsing IDEActivityLogMessage \(classRefToken)")
         }
         if className == String(describing: IDEActivityLogMessage.self) ||
-            className == "IDEClangDiagnosticActivityLogMessage" {
+            className == "IDEClangDiagnosticActivityLogMessage" ||
+            className == "IDEDiagnosticActivityLogMessage" {
             return try parseIDEActivityLogMessage(iterator: &iterator)
         }
         if className ==  String(describing: IDEActivityLogAnalyzerResultMessage.self) {

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.15"
+    public static let current = "0.2.16"
 
 }

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -40,7 +40,8 @@ extension Notice {
                     let type: NoticeType = warningFlag.contains("-Werror") ? .clangError : .clangWarning
                     let notice = Notice(withType: type, logMessage: message, clangFlag: warningFlag)
 
-                    if let notice = notice, isDeprecatedWarning(type: type, text: notice.title, clangFlags: warningFlag) {
+                    if let notice = notice,
+                        isDeprecatedWarning(type: type, text: notice.title, clangFlags: warningFlag) {
                         return notice.with(type: .deprecatedWarning)
                     }
                     return notice

--- a/Tests/XCLogParserTests/ParserTests.swift
+++ b/Tests/XCLogParserTests/ParserTests.swift
@@ -142,7 +142,7 @@ class ParserTests: XCTestCase {
         }
         XCTAssertEqual(warningMessage.title, warning.title)
         XCTAssertEqual("[-Wdeprecated-declarations]", warning.clangFlag ?? "empty")
-        XCTAssertEqual(NoticeType.clangWarning, warning.type)
+        XCTAssertEqual(NoticeType.deprecatedWarning, warning.type)
         XCTAssertEqual(textDocumentLocation.startingLineNumber + 1, warning.startingLineNumber)
         XCTAssertEqual(textDocumentLocation.startingColumnNumber + 1, warning.startingColumnNumber)
         XCTAssertNil(warning.interfaceBuilderIdentifier)


### PR DESCRIPTION
1. Parse Xcode12 beta logs
2. Fix an issue where Clang deprecation warnings weren't marked as `.deprecatedWarning`

cc @alrocha @polac24 