### PR TITLE
Parse time trace file paths generated by clang's `-ftime-trace` flag

### DIFF
--- a/Resources/js/step.js
+++ b/Resources/js/step.js
@@ -112,6 +112,8 @@ function showStep() {
     $('#info-duration').html(step.duration + ' secs.');
     $('#info-start-time').html(moment(new Date(step.startTimestamp * 1000)).format(timestampFormat));
     $('#info-end-time').html(moment(new Date(step.endTimestamp * 1000)).format(timestampFormat));
+    $('#info-time-trace-file').html(step.clangTimeTraceFile);
+    $('#info-time-trace-file').attr("href", step.clangTimeTraceFile);
     showStepErrors(step);
     showStepWarnings(step);
     showSwiftFunctionTimes(step);

--- a/Resources/step.html
+++ b/Resources/step.html
@@ -106,6 +106,14 @@
                       <div id="info-arch"></div>
                     </div>
                   </div>
+                  <div class="row">
+                    <div class="col-sm-2">
+                      Time trace file
+                    </div>
+                    <div class="col-sm-10">
+                      <a id="info-time-trace-file" href=""></a>
+                    </div>
+                  </div>
                 </div> <!-- card body -->
               </div> <!-- collapse-info -->
             </div> <!-- card -->

--- a/Sources/XCLogParser/generated/HtmlReporterResources.swift
+++ b/Sources/XCLogParser/generated/HtmlReporterResources.swift
@@ -1149,6 +1149,14 @@ public static let stepHTML =
                       <div id="info-arch"></div>
                     </div>
                   </div>
+                  <div class="row">
+                    <div class="col-sm-2">
+                      Time trace file
+                    </div>
+                    <div class="col-sm-10">
+                      <a id="info-time-trace-file" href=""></a>
+                    </div>
+                  </div>
                 </div> <!-- card body -->
               </div> <!-- collapse-info -->
             </div> <!-- card -->
@@ -1406,6 +1414,8 @@ function showStep() {
     $('#info-duration').html(step.duration + ' secs.');
     $('#info-start-time').html(moment(new Date(step.startTimestamp * 1000)).format(timestampFormat));
     $('#info-end-time').html(moment(new Date(step.endTimestamp * 1000)).format(timestampFormat));
+    $('#info-time-trace-file').html(step.clangTimeTraceFile);
+    $('#info-time-trace-file').attr("href", step.clangTimeTraceFile);
     showStepErrors(step);
     showStepWarnings(step);
     showSwiftFunctionTimes(step);

--- a/Sources/XCLogParser/parser/BuildStep+Builder.swift
+++ b/Sources/XCLogParser/parser/BuildStep+Builder.swift
@@ -49,7 +49,8 @@ extension BuildStep {
                          swiftFunctionTimes: swiftFunctionTimes,
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
-                         compilationDuration: compilationDuration
+                         compilationDuration: compilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile
         )
     }
 
@@ -81,7 +82,8 @@ extension BuildStep {
                          swiftFunctionTimes: swiftFunctionTimes,
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
-                         compilationDuration: compilationDuration)
+                         compilationDuration: compilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile)
     }
 
     func with(signature newSignature: String) -> BuildStep {
@@ -112,7 +114,8 @@ extension BuildStep {
                          swiftFunctionTimes: swiftFunctionTimes,
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
-                         compilationDuration: compilationDuration)
+                         compilationDuration: compilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile)
     }
 
     func withFilteredNotices() -> BuildStep {
@@ -146,7 +149,8 @@ extension BuildStep {
                          swiftFunctionTimes: swiftFunctionTimes,
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
-                         compilationDuration: compilationDuration)
+                         compilationDuration: compilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile)
     }
 
     func with(subSteps newSubSteps: [BuildStep]) -> BuildStep {
@@ -177,7 +181,8 @@ extension BuildStep {
                          swiftFunctionTimes: swiftFunctionTimes,
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
-                         compilationDuration: compilationDuration)
+                         compilationDuration: compilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile)
     }
 
     func with(newCompilationEndTimestamp: Double,
@@ -209,7 +214,8 @@ extension BuildStep {
                          swiftFunctionTimes: swiftFunctionTimes,
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: newCompilationEndTimestamp,
-                         compilationDuration: newCompilationDuration)
+                         compilationDuration: newCompilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile)
     }
 
     func with(identifier newIdentifier: String) -> BuildStep {
@@ -240,8 +246,8 @@ extension BuildStep {
                          swiftFunctionTimes: swiftFunctionTimes,
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
-                         compilationDuration: compilationDuration
-        )
+                         compilationDuration: compilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile)
     }
 
     private func filterNotices(_ notices: [Notice]?) -> [Notice]? {

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -243,7 +243,7 @@ public struct BuildStep: Encodable {
 
     /// Clang's time trace file path
     /// If the project was compiled with the clang flag `-ftime-trace`
-    /// This filed will be populated
+    /// This field will be populated
     public var clangTimeTraceFile: String?
 
     /// Public initializer 

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -241,6 +241,11 @@ public struct BuildStep: Encodable {
     /// For steps that are't compilation steps such as `.scriptExecution` this will be 0
     public var compilationDuration: Double
 
+    /// Clang's time trace file path
+    /// If the project was compiled with the clang flag `-ftime-trace`
+    /// This filed will be populated
+    public var clangTimeTraceFile: String?
+
     /// Public initializer 
     public init(type: BuildStepType,
                 machineName: String,
@@ -269,7 +274,8 @@ public struct BuildStep: Encodable {
                 swiftFunctionTimes: [SwiftFunctionTime]?,
                 fetchedFromCache: Bool,
                 compilationEndTimestamp: Double,
-                compilationDuration: Double) {
+                compilationDuration: Double,
+                clangTimeTraceFile: String?) {
         self.type = type
         self.machineName = machineName
         self.buildIdentifier = buildIdentifier
@@ -298,6 +304,7 @@ public struct BuildStep: Encodable {
         self.fetchedFromCache = fetchedFromCache
         self.compilationEndTimestamp = compilationEndTimestamp
         self.compilationDuration = compilationDuration
+        self.clangTimeTraceFile = clangTimeTraceFile
     }
 }
 

--- a/Sources/XCLogParser/parser/ClangCompilerParser.swift
+++ b/Sources/XCLogParser/parser/ClangCompilerParser.swift
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+public class ClangCompilerParser {
+    private static let timeTraceCompilerFlag = "-ftime-trace"
+
+    private lazy var timeTraceRegexp: NSRegularExpression? = {
+        let pattern = "Time trace json-file dumped to (.*?)\\r"
+        return NSRegularExpression.fromPattern(pattern)
+    }()
+
+    public func parseTimeTraceFile(_ logSection: IDEActivityLogSection) -> String? {
+        guard let regex = timeTraceRegexp else {
+            return nil
+        }
+
+        guard hasTimeTraceCompilerFlag(commandDesc: logSection.commandDetailDesc) else {
+            return nil
+        }
+
+        let text = logSection.text
+        let range = NSRange(location: 0, length: text.count)
+        let matches = regex.matches(in: text, options: .reportProgress, range: range)
+        guard let fileRange = matches.first?.range(at: 1) else {
+            return nil
+        }
+
+        return text.substring(fileRange)
+    }
+
+    func hasTimeTraceCompilerFlag(commandDesc: String) -> Bool {
+        commandDesc.range(of: Self.timeTraceCompilerFlag) != nil
+    }
+}

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -32,6 +32,7 @@ public final class ParserBuildSteps {
     var targetErrors = 0
     var targetWarnings = 0
     let swiftCompilerParser = SwiftCompilerParser()
+    let clangCompilerParser = ClangCompilerParser()
 
     public lazy var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -153,7 +154,8 @@ public final class ParserBuildSteps {
                                  fetchedFromCache: wasFetchedFromCache(parent:
                                     parentSection, section: logSection),
                                  compilationEndTimestamp: 0,
-                                 compilationDuration: 0
+                                 compilationDuration: 0,
+                                 clangTimeTraceFile: nil
                                  )
 
             step.subSteps = try logSection.subSections.map { subSection -> BuildStep in
@@ -181,6 +183,11 @@ public final class ParserBuildSteps {
                     step = step.withFilteredNotices()
                 }
             }
+
+            if step.fetchedFromCache == false && step.detailStepType == .cCompilation {
+                step.clangTimeTraceFile = "file://\(clangCompilerParser.parseTimeTraceFile(logSection) ?? "")"
+            }
+
             step = addCompilationTimes(step: step)
             return step
     }

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -91,7 +91,7 @@ public final class ParserBuildSteps {
         return mainBuildStep
     }
 
-    // swiftlint:disable function_body_length
+    // swiftlint:disable function_body_length cyclomatic_complexity
     public func parseLogSection(logSection: IDEActivityLogSection,
                                 type: BuildStepType,
                                 parentSection: BuildStep?,

--- a/Tests/XCLogParserTests/BuildStep+TestUtils.swift
+++ b/Tests/XCLogParserTests/BuildStep+TestUtils.swift
@@ -33,5 +33,6 @@ func makeFakeBuildStep(title: String,
                      swiftFunctionTimes: nil,
                      fetchedFromCache: fetchedFromCache,
                      compilationEndTimestamp: 0,
-                     compilationDuration: 0)
+                     compilationDuration: 0,
+                     clangTimeTraceFile: nil)
 }

--- a/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
+++ b/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
@@ -80,7 +80,8 @@ class ChromeTracerOutputTests: XCTestCase {
                              swiftFunctionTimes: nil,
                              fetchedFromCache: false,
                              compilationEndTimestamp: end.timeIntervalSince1970,
-                             compilationDuration: 100 * 100
+                             compilationDuration: 100 * 100,
+                             clangTimeTraceFile: nil
                              )
         return root
     }
@@ -115,7 +116,8 @@ class ChromeTracerOutputTests: XCTestCase {
                              swiftFunctionTimes: nil,
                              fetchedFromCache: false,
                              compilationEndTimestamp: end.timeIntervalSince1970,
-                             compilationDuration: 50 * 100
+                             compilationDuration: 50 * 100,
+                             clangTimeTraceFile: nil
                              )
 
         let end2 = end.addingTimeInterval(50 * 100)
@@ -146,7 +148,8 @@ class ChromeTracerOutputTests: XCTestCase {
                                 swiftFunctionTimes: nil,
                                 fetchedFromCache: false,
                                 compilationEndTimestamp: end2.timeIntervalSince1970,
-                                compilationDuration: 50 * 100
+                                compilationDuration: 50 * 100,
+                                clangTimeTraceFile: nil
                                 )
         return [target1, target2]
 

--- a/Tests/XCLogParserTests/ClangCompilerParserTests.swift
+++ b/Tests/XCLogParserTests/ClangCompilerParserTests.swift
@@ -24,9 +24,11 @@ class ClangCompilerParserTests: XCTestCase {
     let parser = ClangCompilerParser()
 
     func testParseTimeTraceFile() throws {
-        let clangCompileLogSection = getFakeClangSection(text:
-            "Time trace json-file dumped to /Users/project/ObjectsDirectory/UIViewController+Utility.json\rUse chrome://tracing or Speedscope App (https://www.speedscope.app) for flamegraph visualization\r",
-        commandDescription: "-ftime-trace")
+        let text = """
+        Time trace json-file dumped to /Users/project/ObjectsDirectory/UIViewController+Utility.json\r\
+        Use chrome://tracing or Speedscope App (https://www.speedscope.app) for flamegraph visualization\r
+        """
+        let clangCompileLogSection = getFakeClangSection(text: text, commandDescription: "-ftime-trace")
 
         let expectedFile = "/Users/project/ObjectsDirectory/UIViewController+Utility.json"
         let timeTraceFile = parser.parseTimeTraceFile(clangCompileLogSection)

--- a/Tests/XCLogParserTests/ClangCompilerParserTests.swift
+++ b/Tests/XCLogParserTests/ClangCompilerParserTests.swift
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import XCTest
+@testable import XCLogParser
+
+class ClangCompilerParserTests: XCTestCase {
+    let parser = ClangCompilerParser()
+
+    func testParseTimeTraceFile() throws {
+        let clangCompileLogSection = getFakeClangSection(text:
+            "Time trace json-file dumped to /Users/project/ObjectsDirectory/UIViewController+Utility.json\rUse chrome://tracing or Speedscope App (https://www.speedscope.app) for flamegraph visualization\r",
+        commandDescription: "-ftime-trace")
+
+        let expectedFile = "/Users/project/ObjectsDirectory/UIViewController+Utility.json"
+        let timeTraceFile = parser.parseTimeTraceFile(clangCompileLogSection)
+        XCTAssertEqual(expectedFile, timeTraceFile)
+    }
+
+    private func getFakeClangSection(text: String, commandDescription: String) -> IDEActivityLogSection {
+        return IDEActivityLogSection(sectionType: 1,
+                                     domainType: "",
+                                     title: "Clang Compilation",
+                                     signature: "",
+                                     timeStartedRecording: 0.0,
+                                     timeStoppedRecording: 0.0,
+                                     subSections: [],
+                                     text: text,
+                                     messages: [],
+                                     wasCancelled: false,
+                                     isQuiet: false,
+                                     wasFetchedFromCache: false,
+                                     subtitle: "",
+                                     location: DVTDocumentLocation(documentURLString: "", timestamp: 0.0),
+                                     commandDetailDesc: commandDescription,
+                                     uniqueIdentifier: "",
+                                     localizedResultString: "",
+                                     xcbuildSignature: "",
+                                     unknown: 0)
+    }
+}

--- a/Tests/XCLogParserTests/IssuesReporterTests.swift
+++ b/Tests/XCLogParserTests/IssuesReporterTests.swift
@@ -77,7 +77,8 @@ class IssuesReporterTests: XCTestCase {
                              swiftFunctionTimes: nil,
                              fetchedFromCache: false,
                              compilationEndTimestamp: end.timeIntervalSince1970,
-                             compilationDuration: 100 * 100
+                             compilationDuration: 100 * 100,
+                             clangTimeTraceFile: nil
         )
         return root
     }
@@ -126,7 +127,8 @@ class IssuesReporterTests: XCTestCase {
                              swiftFunctionTimes: nil,
                              fetchedFromCache: false,
                              compilationEndTimestamp: end.timeIntervalSince1970,
-                             compilationDuration: 100 * 100
+                             compilationDuration: 100 * 100,
+                             clangTimeTraceFile: nil
         )
         return root
     }
@@ -175,7 +177,8 @@ class IssuesReporterTests: XCTestCase {
                          swiftFunctionTimes: nil,
                          fetchedFromCache: false,
                          compilationEndTimestamp: end.timeIntervalSince1970,
-                         compilationDuration: 100 * 100
+                         compilationDuration: 100 * 100,
+                         clangTimeTraceFile: nil
         )
     }
 }


### PR DESCRIPTION
Clang's time trace feature is useful for build performance analysis. When the `-ftime-trace` flag is specified, clang will generate    a `.json` tracing file for each translation unit. This patch will extract the path of these files from build log.