### PR TITLE
Parse ld64 linker statistics

### DIFF
--- a/Sources/XCLogParser/parser/BuildStep+Builder.swift
+++ b/Sources/XCLogParser/parser/BuildStep+Builder.swift
@@ -50,7 +50,8 @@ extension BuildStep {
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
-                         clangTimeTraceFile: clangTimeTraceFile
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics
         )
     }
 
@@ -83,7 +84,8 @@ extension BuildStep {
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
-                         clangTimeTraceFile: clangTimeTraceFile)
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics)
     }
 
     func with(signature newSignature: String) -> BuildStep {
@@ -115,7 +117,8 @@ extension BuildStep {
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
-                         clangTimeTraceFile: clangTimeTraceFile)
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics)
     }
 
     func withFilteredNotices() -> BuildStep {
@@ -150,7 +153,8 @@ extension BuildStep {
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
-                         clangTimeTraceFile: clangTimeTraceFile)
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics)
     }
 
     func with(subSteps newSubSteps: [BuildStep]) -> BuildStep {
@@ -182,7 +186,8 @@ extension BuildStep {
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
-                         clangTimeTraceFile: clangTimeTraceFile)
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics)
     }
 
     func with(newCompilationEndTimestamp: Double,
@@ -215,7 +220,8 @@ extension BuildStep {
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: newCompilationEndTimestamp,
                          compilationDuration: newCompilationDuration,
-                         clangTimeTraceFile: clangTimeTraceFile)
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics)
     }
 
     func with(identifier newIdentifier: String) -> BuildStep {
@@ -247,7 +253,8 @@ extension BuildStep {
                          fetchedFromCache: fetchedFromCache,
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
-                         clangTimeTraceFile: clangTimeTraceFile)
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics)
     }
 
     private func filterNotices(_ notices: [Notice]?) -> [Notice]? {

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -246,6 +246,11 @@ public struct BuildStep: Encodable {
     /// This field will be populated
     public var clangTimeTraceFile: String?
 
+    /// ld64's statistics info
+    /// If the project was compiled with `-Xlinker -print_statistics`
+    /// This field will be populated
+    public var linkerStatistics: LinkerStatistics?
+
     /// Public initializer 
     public init(type: BuildStepType,
                 machineName: String,
@@ -275,7 +280,8 @@ public struct BuildStep: Encodable {
                 fetchedFromCache: Bool,
                 compilationEndTimestamp: Double,
                 compilationDuration: Double,
-                clangTimeTraceFile: String?) {
+                clangTimeTraceFile: String?,
+                linkerStatistics: LinkerStatistics?) {
         self.type = type
         self.machineName = machineName
         self.buildIdentifier = buildIdentifier
@@ -305,6 +311,7 @@ public struct BuildStep: Encodable {
         self.compilationEndTimestamp = compilationEndTimestamp
         self.compilationDuration = compilationDuration
         self.clangTimeTraceFile = clangTimeTraceFile
+        self.linkerStatistics = linkerStatistics
     }
 }
 

--- a/Sources/XCLogParser/parser/ClangCompilerParser.swift
+++ b/Sources/XCLogParser/parser/ClangCompilerParser.swift
@@ -21,6 +21,7 @@ import Foundation
 
 public class ClangCompilerParser {
     private static let timeTraceCompilerFlag = "-ftime-trace"
+    private static let printStatisticsLinkerFlag = "-print_statistics"
 
     private lazy var timeTraceRegexp: NSRegularExpression? = {
         let pattern = "Time trace json-file dumped to (.*?)\\r"
@@ -46,7 +47,144 @@ public class ClangCompilerParser {
         return text.substring(fileRange)
     }
 
+    fileprivate func parseTimeAndPercentage(_ text: String, _ range: NSRange, _ pattern: String) -> (Double, Double) {
+        var time = 0.0
+        var percentage = 0.0
+
+        if let regex = NSRegularExpression.fromPattern(pattern) {
+            if let match = regex.firstMatch(in: text, options: [], range: range) {
+                if let timeRange = Range(match.range(at: 1), in: text) {
+                    time = Double(text[timeRange]) ?? 0.0
+                }
+
+                if let percentageRange = Range(match.range(at: 2), in: text) {
+                    percentage = Double(text[percentageRange]) ?? 0.0
+                }
+            }
+        }
+
+        return (time, percentage)
+    }
+
+    // swiftlint:disable large_tuple
+    fileprivate func parsePagingInfo(_ text: String, _ range: NSRange) -> (Int, Int, Int) {
+        var pageins = 0, pageouts = 0, faults = 0
+        let pagingInfoPattern = "pageins=(\\d+), pageouts=(\\d+), faults=(\\d+)\r"
+        if let regex = NSRegularExpression.fromPattern(pagingInfoPattern) {
+            if let match = regex.firstMatch(in: text, options: [], range: range) {
+                if let pageinsRange = Range(match.range(at: 1), in: text) {
+                    pageins = Int(text[pageinsRange]) ?? 0
+                }
+                if let pageoutsRange = Range(match.range(at: 2), in: text) {
+                    pageouts = Int(text[pageoutsRange]) ?? 0
+                }
+                if let faultsRange = Range(match.range(at: 3), in: text) {
+                    faults = Int(text[faultsRange]) ?? 0
+                }
+            }
+        }
+
+        return (pageins, pageouts, faults)
+    }
+
+    // swiftlint:disable function_body_length
+    public func parseLinkerStatistics(_ logSection: IDEActivityLogSection) -> LinkerStatistics? {
+        guard hasPrintStatisticsLinkerFlag(commandDesc: logSection.commandDetailDesc) else {
+            return nil
+        }
+
+        let text = logSection.text
+        let range = NSRange(location: 0, length: text.count)
+        let totalTimePattern = "ld total time:\\s*(.*?) milliseconds \\(\\s*(.*?)%\\)\\r"
+        let totalTime = parseTimeAndPercentage(text, range, totalTimePattern)
+
+        let optionParsingPattern = "option parsing time:\\s*(.*?) milliseconds \\(\\s*(.*?)%\\)\\r"
+        let optionParsing = parseTimeAndPercentage(text, range, optionParsingPattern)
+
+        let resolveSymbolPattern = "resolve symbols:\\s*(.*?) milliseconds \\(\\s*(.*?)%\\)\\r"
+        let resolveSymbol = parseTimeAndPercentage(text, range, resolveSymbolPattern)
+
+        let buildAtomPattern = "build atom list:\\s*(.*?) milliseconds \\(\\s*(.*?)%\\)\\r"
+        let buildAtom = parseTimeAndPercentage(text, range, buildAtomPattern)
+
+        let passesPattern = "passess:\\s*(.*?) milliseconds \\(\\s*(.*?)%\\)\\r"
+        let passes = parseTimeAndPercentage(text, range, passesPattern)
+
+        let writeOutputPattern = "write output:\\s*(.*?) milliseconds \\(\\s*(.*?)%\\)\\r"
+        let writeOutput = parseTimeAndPercentage(text, range, writeOutputPattern)
+
+        let paging = parsePagingInfo(text, range)
+
+        var objectFiles = 0, objectFilesBytes = 0
+        var archiveFiles = 0, archiveFilesBytes = 0
+        var dylibFiles = 0
+        var totalFileBytes = 0
+
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+
+        let fileInfoPattern = """
+        processed\\s*(\\d+) object files,\\s*totaling\\s*(.*?) bytes\\r\
+        processed\\s*(\\d+) archive files,\\s*totaling\\s*(.*?) bytes\\r\
+        processed\\s*(\\d+) dylib files\\r\
+        wrote output file\\s* totaling\\s*(.*) bytes\\r
+        """
+        if let regex = NSRegularExpression.fromPattern(fileInfoPattern) {
+            if let match = regex.firstMatch(in: text, options: [], range: range) {
+                if let objectFilesCountRange = Range(match.range(at: 1), in: text) {
+                    objectFiles = Int(text[objectFilesCountRange]) ?? 0
+                }
+                if let objectFilesBytesRange = Range(match.range(at: 2), in: text) {
+                    let number = numberFormatter.number(from: String(text[objectFilesBytesRange]))
+                    objectFilesBytes = number?.intValue ?? 0
+                }
+                if let archiveFilesCountRange = Range(match.range(at: 3), in: text) {
+                    archiveFiles = Int(text[archiveFilesCountRange]) ?? 0
+                }
+                if let archiveFilesBytesRange = Range(match.range(at: 4), in: text) {
+                    let number = numberFormatter.number(from: String(text[archiveFilesBytesRange]))
+                    archiveFilesBytes = number?.intValue ?? 0
+                }
+                if let dylibCountRange = Range(match.range(at: 5), in: text) {
+                    dylibFiles = Int(text[dylibCountRange]) ?? 0
+                }
+                if let totalFilesBytesRange = Range(match.range(at: 6), in: text) {
+                    let number = numberFormatter.number(from: String(text[totalFilesBytesRange]))
+                    totalFileBytes = number?.intValue ?? 0
+                }
+            }
+        }
+
+        return LinkerStatistics(
+            totalMS: totalTime.0,
+            optionParsingMS: optionParsing.0,
+            optionParsingPercent: optionParsing.1,
+            objectFileProcessingMS: 0,
+            objectFileProcessingPercent: 0,
+            resolveSymbolsMS: resolveSymbol.0,
+            resolveSymbolsPercent: resolveSymbol.1,
+            buildAtomListMS: buildAtom.0,
+            buildAtomListPercent: buildAtom.1,
+            runPassesMS: passes.0,
+            runPassesPercent: passes.1,
+            writeOutputMS: writeOutput.0,
+            writeOutputPercent: writeOutput.1,
+            pageins: paging.0,
+            pageouts: paging.1,
+            faults: paging.2,
+            objectFiles: objectFiles,
+            objectFilesBytes: objectFilesBytes,
+            archiveFiles: archiveFiles,
+            archiveFilesBytes: archiveFilesBytes,
+            dylibFiles: dylibFiles,
+            wroteOutputFileBytes: totalFileBytes)
+    }
+
     func hasTimeTraceCompilerFlag(commandDesc: String) -> Bool {
         commandDesc.range(of: Self.timeTraceCompilerFlag) != nil
+    }
+
+    func hasPrintStatisticsLinkerFlag(commandDesc: String) -> Bool {
+        commandDesc.range(of: Self.printStatisticsLinkerFlag) != nil
     }
 }

--- a/Sources/XCLogParser/parser/LinkerStatistics.swift
+++ b/Sources/XCLogParser/parser/LinkerStatistics.swift
@@ -1,0 +1,103 @@
+// Copyright (c) 2019 Spotify AB.
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+/// Wrap the statistics data produced by ld64 linker (-print_statistics)
+public class LinkerStatistics: Encodable {
+    public let totalMS: Double
+
+    public let optionParsingMS: Double
+    public let optionParsingPercent: Double
+
+    public let objectFileProcessingMS: Double
+    public let objectFileProcessingPercent: Double
+
+    public let resolveSymbolsMS: Double
+    public let resolveSymbolsPercent: Double
+
+    public let buildAtomListMS: Double
+    public let buildAtomListPercent: Double
+
+    public let runPassesMS: Double
+    public let runPassesPercent: Double
+
+    public let writeOutputMS: Double
+    public let writeOutputPercent: Double
+
+    public let pageins: Int
+    public let pageouts: Int
+    public let faults: Int
+
+    public let objectFiles: Int
+    public let objectFilesBytes: Int
+
+    public let archiveFiles: Int
+    public let archiveFilesBytes: Int
+
+    public let dylibFiles: Int
+    public let wroteOutputFileBytes: Int
+
+    public init(totalMS: Double,
+                optionParsingMS: Double,
+                optionParsingPercent: Double,
+                objectFileProcessingMS: Double,
+                objectFileProcessingPercent: Double,
+                resolveSymbolsMS: Double,
+                resolveSymbolsPercent: Double,
+                buildAtomListMS: Double,
+                buildAtomListPercent: Double,
+                runPassesMS: Double,
+                runPassesPercent: Double,
+                writeOutputMS: Double,
+                writeOutputPercent: Double,
+                pageins: Int,
+                pageouts: Int,
+                faults: Int,
+                objectFiles: Int,
+                objectFilesBytes: Int,
+                archiveFiles: Int,
+                archiveFilesBytes: Int,
+                dylibFiles: Int,
+                wroteOutputFileBytes: Int) {
+        self.totalMS = totalMS
+        self.optionParsingMS = optionParsingMS
+        self.optionParsingPercent = optionParsingPercent
+        self.objectFileProcessingMS = objectFileProcessingMS
+        self.objectFileProcessingPercent = objectFileProcessingPercent
+        self.resolveSymbolsMS = resolveSymbolsMS
+        self.resolveSymbolsPercent = resolveSymbolsPercent
+        self.buildAtomListMS = buildAtomListMS
+        self.buildAtomListPercent = buildAtomListPercent
+        self.runPassesMS = runPassesMS
+        self.runPassesPercent = runPassesPercent
+        self.writeOutputMS = writeOutputMS
+        self.writeOutputPercent = writeOutputPercent
+        self.pageins = pageins
+        self.pageouts = pageouts
+        self.faults = faults
+        self.objectFiles = objectFiles
+        self.objectFilesBytes = objectFilesBytes
+        self.archiveFiles = archiveFiles
+        self.archiveFilesBytes = archiveFilesBytes
+        self.dylibFiles = dylibFiles
+        self.wroteOutputFileBytes = wroteOutputFileBytes
+    }
+
+}

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -155,7 +155,8 @@ public final class ParserBuildSteps {
                                     parentSection, section: logSection),
                                  compilationEndTimestamp: 0,
                                  compilationDuration: 0,
-                                 clangTimeTraceFile: nil
+                                 clangTimeTraceFile: nil,
+                                 linkerStatistics: nil
                                  )
 
             step.subSteps = try logSection.subSections.map { subSection -> BuildStep in
@@ -186,6 +187,10 @@ public final class ParserBuildSteps {
 
             if step.fetchedFromCache == false && step.detailStepType == .cCompilation {
                 step.clangTimeTraceFile = "file://\(clangCompilerParser.parseTimeTraceFile(logSection) ?? "")"
+            }
+
+            if step.fetchedFromCache == false && step.detailStepType == .linker {
+                step.linkerStatistics = clangCompilerParser.parseLinkerStatistics(logSection)
             }
 
             step = addCompilationTimes(step: step)

--- a/Tests/XCLogParserTests/BuildStep+TestUtils.swift
+++ b/Tests/XCLogParserTests/BuildStep+TestUtils.swift
@@ -34,5 +34,6 @@ func makeFakeBuildStep(title: String,
                      fetchedFromCache: fetchedFromCache,
                      compilationEndTimestamp: 0,
                      compilationDuration: 0,
-                     clangTimeTraceFile: nil)
+                     clangTimeTraceFile: nil,
+                     linkerStatistics: nil)
 }

--- a/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
+++ b/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
@@ -81,7 +81,8 @@ class ChromeTracerOutputTests: XCTestCase {
                              fetchedFromCache: false,
                              compilationEndTimestamp: end.timeIntervalSince1970,
                              compilationDuration: 100 * 100,
-                             clangTimeTraceFile: nil
+                             clangTimeTraceFile: nil,
+                             linkerStatistics: nil
                              )
         return root
     }
@@ -117,7 +118,8 @@ class ChromeTracerOutputTests: XCTestCase {
                              fetchedFromCache: false,
                              compilationEndTimestamp: end.timeIntervalSince1970,
                              compilationDuration: 50 * 100,
-                             clangTimeTraceFile: nil
+                             clangTimeTraceFile: nil,
+                             linkerStatistics: nil
                              )
 
         let end2 = end.addingTimeInterval(50 * 100)
@@ -149,7 +151,8 @@ class ChromeTracerOutputTests: XCTestCase {
                                 fetchedFromCache: false,
                                 compilationEndTimestamp: end2.timeIntervalSince1970,
                                 compilationDuration: 50 * 100,
-                                clangTimeTraceFile: nil
+                                clangTimeTraceFile: nil,
+                                linkerStatistics: nil
                                 )
         return [target1, target2]
 

--- a/Tests/XCLogParserTests/ClangCompilerParserTests.swift
+++ b/Tests/XCLogParserTests/ClangCompilerParserTests.swift
@@ -35,6 +35,47 @@ class ClangCompilerParserTests: XCTestCase {
         XCTAssertEqual(expectedFile, timeTraceFile)
     }
 
+    func testParseLinkerStatistics() throws {
+        let text = """
+        ld total time:  561.6 milliseconds ( 100.0%)\r\
+        option parsing time:   51.7 milliseconds (   9.2%)\r\
+        object file processing:    0.0 milliseconds (   0.0%)\r\
+        resolve symbols:  336.1 milliseconds (  59.8%)\r\
+        build atom list:    0.0 milliseconds (   0.0%)\r\
+        passess:   97.3 milliseconds (  17.3%)\r\
+        write output:   76.3 milliseconds (  13.5%)\r\
+        pageins=7464, pageouts=0, faults=31012\r\
+        processed   5 object files,  totaling         140,932 bytes\r\
+        processed  42 archive files, totaling      24,362,016 bytes\r\
+        processed  87 dylib files\r\
+        wrote output file            totaling       8,758,732 bytes\r
+        """
+        let clangCompileLogSection = getFakeClangSection(text: text, commandDescription: "-print_statistics")
+        let statistics = parser.parseLinkerStatistics(clangCompileLogSection)!
+        XCTAssertEqual(statistics.totalMS, 561.6, accuracy: 0.0001)
+        XCTAssertEqual(statistics.optionParsingMS, 51.7, accuracy: 0.0001)
+        XCTAssertEqual(statistics.optionParsingPercent, 9.2, accuracy: 0.0001)
+        XCTAssertEqual(statistics.objectFileProcessingMS, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(statistics.objectFileProcessingPercent, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(statistics.resolveSymbolsMS, 336.1, accuracy: 0.0001)
+        XCTAssertEqual(statistics.resolveSymbolsPercent, 59.8, accuracy: 0.0001)
+        XCTAssertEqual(statistics.buildAtomListMS, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(statistics.buildAtomListPercent, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(statistics.runPassesMS, 97.3, accuracy: 0.0001)
+        XCTAssertEqual(statistics.runPassesPercent, 17.3, accuracy: 0.0001)
+        XCTAssertEqual(statistics.writeOutputMS, 76.3, accuracy: 0.0001)
+        XCTAssertEqual(statistics.writeOutputPercent, 13.5, accuracy: 0.0001)
+        XCTAssertEqual(statistics.pageins, 7464)
+        XCTAssertEqual(statistics.pageouts, 0)
+        XCTAssertEqual(statistics.faults, 31012)
+        XCTAssertEqual(statistics.objectFiles, 5)
+        XCTAssertEqual(statistics.objectFilesBytes, 140932)
+        XCTAssertEqual(statistics.archiveFiles, 42)
+        XCTAssertEqual(statistics.archiveFilesBytes, 24362016)
+        XCTAssertEqual(statistics.dylibFiles, 87)
+        XCTAssertEqual(statistics.wroteOutputFileBytes, 8758732)
+    }
+
     private func getFakeClangSection(text: String, commandDescription: String) -> IDEActivityLogSection {
         return IDEActivityLogSection(sectionType: 1,
                                      domainType: "",

--- a/Tests/XCLogParserTests/IssuesReporterTests.swift
+++ b/Tests/XCLogParserTests/IssuesReporterTests.swift
@@ -78,7 +78,8 @@ class IssuesReporterTests: XCTestCase {
                              fetchedFromCache: false,
                              compilationEndTimestamp: end.timeIntervalSince1970,
                              compilationDuration: 100 * 100,
-                             clangTimeTraceFile: nil
+                             clangTimeTraceFile: nil,
+                             linkerStatistics: nil
         )
         return root
     }
@@ -128,7 +129,8 @@ class IssuesReporterTests: XCTestCase {
                              fetchedFromCache: false,
                              compilationEndTimestamp: end.timeIntervalSince1970,
                              compilationDuration: 100 * 100,
-                             clangTimeTraceFile: nil
+                             clangTimeTraceFile: nil,
+                             linkerStatistics: nil
         )
         return root
     }
@@ -178,7 +180,8 @@ class IssuesReporterTests: XCTestCase {
                          fetchedFromCache: false,
                          compilationEndTimestamp: end.timeIntervalSince1970,
                          compilationDuration: 100 * 100,
-                         clangTimeTraceFile: nil
+                         clangTimeTraceFile: nil,
+                         linkerStatistics: nil
         )
     }
 }


### PR DESCRIPTION
This patch parses the ld64's statistics output. The statistics info can be generated by adding `-Xlinker -print_statistics` to Xcode's "Other Linker Flags" and it's useful for tracking linking time regression.