### PR TITLE
Bug fixes

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.17"
+    public static let current = "0.2.18"
 
 }

--- a/Sources/XCLogParser/parser/ClangCompilerParser.swift
+++ b/Sources/XCLogParser/parser/ClangCompilerParser.swift
@@ -121,6 +121,7 @@ public class ClangCompilerParser {
         var totalFileBytes = 0
 
         let numberFormatter = NumberFormatter()
+        numberFormatter.locale = Locale(identifier: "en")
         numberFormatter.numberStyle = .decimal
 
         let fileInfoPattern = """

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -62,11 +62,11 @@ extension Notice {
                     // Special case, if Swiftc fails for a whole module,
                     // we don't have location and the detail already has
                     // enough information
-                    if let detail = notice.detail, detail.starts(with: "error:") == false {
+                    let noticeDetail = notice.detail ?? ""
+                    if noticeDetail.starts(with: "error:") == false {
                         var errorLocation = notice.documentURL.replacingOccurrences(of: "file://", with: "")
                         errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
-
-                            notice = notice.with(detail: swiftErrorDetails[errorLocation])
+                        notice = notice.with(detail: swiftErrorDetails[errorLocation])
                     }
                 }
 

--- a/Sources/XCLogParser/parser/NoticeType.swift
+++ b/Sources/XCLogParser/parser/NoticeType.swift
@@ -87,6 +87,8 @@ public enum NoticeType: String, Codable {
             return .packageLoadingError
         case Contains("Command PhaseScriptExecution"):
             return .scriptPhaseError
+        case Prefix("error: Swiftc"):
+            return .swiftError
         default:
             return .note
         }


### PR DESCRIPTION
1. Fixes a bug in the linker stats parser that relied on using decimal points to parse a number
2. Fixes a bug that was causing errors in the Swift Compiler to be reported as notices

cc @alrocha @BalestraPatrick @polac24 