### PR TITLE
Integrate removing build specific information

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ An example output has been omitted for brevity since it can contain a lot of inf
   | `--derived_data`  | The path to the derived data folder if you are using `xcodebuild` to build your project with the `-derivedDataPath` option.  | No |
   | `--output`  | If specified, the JSON file will be written to the given path. If not defined, the command will output to the standard output.  | No |
   | `--redacted`  | If specified, the username will be replaced by the word `redacted` in the file paths contained in the logs. Useful for privacy reasons but slightly decreases the performance.  | No |
+  | `--without_build_specific_info`  | If specified, build specific information will be removed from the logs (for example `bolnckhlbzxpxoeyfujluasoupft` will be removed from  `DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build` ). Useful for grouping logs by its content.  | No |
   | `--strictProjectName`  | Used in conjunction with `--project`. If specified, a stricter name matching will be done for the project name.  | No |
 
   >No *: One of `--file`, `--project`, `--workspace`, `--xcodeproj` parameters is required.
@@ -154,6 +155,7 @@ Example output available in the [reporters](#reporters) section.
   | `--derived_data`  | The path to the derived data folder if you are using `xcodebuild` to build your project with the `-derivedDataPath` option.  | No |
   | `--output`  | If specified, the JSON file will be written to the given path. If not defined, the command will output to the standard output.  | No |
   | `--redacted`  | If specified, the username will be replaced by the word `redacted` in the file paths contained in the logs. Useful for privacy reasons but slightly decreases the performance.  | No |
+  | `--without_build_specific_info`  | If specified, build specific information will be removed from the logs (for example `bolnckhlbzxpxoeyfujluasoupft` will be removed from  `DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build` ). Useful for grouping logs by its content.  | No |
   | `--strictProjectName`  | Used in conjunction with `--project`. If specified, a stricter name matching will be done for the project name.  | No |
   | `--machine_name`  | If specified, the machine name will be used to create the `buildIdentifier`. If it is not specified, the host name will be used.  | No |
 

--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -36,14 +36,22 @@ public class ActivityParser {
     /// - parameter logURL: `URL` of the xcactivitylog
     /// - parameter redacted: If true, the username will be replaced
     /// in the file paths inside the logs for the word `redacted`.
-    /// This flag is iseful to preserve the privacy of the users.
+    /// This flag is useful to preserve the privacy of the users.
+    /// - parameter withoutBuildSpecificInformation: If true, build specific
+    /// information will be removed from the logs (for example `bolnckhlbzxpxoeyfujluasoupft`
+    /// will be removed from  `DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build`).
+    /// This flag is useful for grouping logs by its content.
     /// - returns: An instance of `IDEActivityLog1
     /// - throws: An Error if the file is not valid.
-    public func parseActivityLogInURL(_ logURL: URL, redacted: Bool) throws -> IDEActivityLog {
+    public func parseActivityLogInURL(_ logURL: URL,
+                                      redacted: Bool,
+                                      withoutBuildSpecificInformation: Bool) throws -> IDEActivityLog {
         let logLoader = LogLoader()
         let content = try logLoader.loadFromURL(logURL)
         let lexer = Lexer(filePath: logURL.path)
-        let tokens = try lexer.tokenize(contents: content, redacted: redacted)
+        let tokens = try lexer.tokenize(contents: content,
+                                        redacted: redacted,
+                                        withoutBuildSpecificInformation: withoutBuildSpecificInformation)
         return try parseIDEActiviyLogFromTokens(tokens)
     }
 

--- a/Sources/XCLogParser/commands/ActionOptions.swift
+++ b/Sources/XCLogParser/commands/ActionOptions.swift
@@ -34,14 +34,24 @@ public struct ActionOptions {
     /// Used to protect the privacy of the users.
     public let redacted: Bool
 
+    /// Used for actions involving the .xcactivitylog.
+    /// If true, build specific information will be removed from the logs.
+    /// Useful for grouping logs by its content.
+    public let withoutBuildSpecificInformation: Bool
+
     /// Used in Parse actions. The current parsers use the host name to create a unique build identifier
     /// With this option, a user can override it and provide a name that will be used in that identifier.
     public let machineName: String?
 
-    public init(reporter: Reporter, outputPath: String, redacted: Bool, machineName: String? = nil) {
+    public init(reporter: Reporter,
+                outputPath: String,
+                redacted: Bool,
+                withoutBuildSpecificInformation: Bool,
+                machineName: String? = nil) {
         self.reporter = reporter
         self.outputPath = outputPath
         self.redacted = redacted
+        self.withoutBuildSpecificInformation = withoutBuildSpecificInformation
         self.machineName = machineName
     }
 }

--- a/Sources/XCLogParser/commands/CommandHandler.swift
+++ b/Sources/XCLogParser/commands/CommandHandler.swift
@@ -49,14 +49,18 @@ public struct CommandHandler {
     }
 
     func handleDump(fromLogURL logURL: URL, options: ActionOptions) throws {
-        let activityLog = try activityLogParser.parseActivityLogInURL(logURL, redacted: options.redacted)
+        let activityLog = try activityLogParser.parseActivityLogInURL(logURL,
+                                                                      redacted: options.redacted,
+                                                                      withoutBuildSpecificInformation: options.withoutBuildSpecificInformation) // swiftlint:disable:this line_length
         let reporterOutput = ReporterOutputFactory.makeReporterOutput(path: options.outputPath)
         let logReporter = options.reporter.makeLogReporter()
         try logReporter.report(build: activityLog, output: reporterOutput)
     }
 
     func handleParse(fromLogURL logURL: URL, options: ActionOptions) throws {
-        let activityLog = try activityLogParser.parseActivityLogInURL(logURL, redacted: options.redacted)
+        let activityLog = try activityLogParser.parseActivityLogInURL(logURL,
+                                                                      redacted: options.redacted,
+                                                                      withoutBuildSpecificInformation: options.withoutBuildSpecificInformation) // swiftlint:disable:this line_length
         let buildParser = ParserBuildSteps(machineName: options.machineName)
         let buildSteps = try buildParser.parse(activityLog: activityLog)
         let reporterOutput = ReporterOutputFactory.makeReporterOutput(path: options.outputPath)

--- a/Sources/XCLogParser/lexer/Lexer.swift
+++ b/Sources/XCLogParser/lexer/Lexer.swift
@@ -27,11 +27,11 @@ public final class Lexer {
     let filePath: String
     var classNames = [String]()
     var userDirToRedact: String? {
-        set {
-            redactor.userDirToRedact = newValue
-        }
         get {
             redactor.userDirToRedact
+        }
+        set {
+            redactor.userDirToRedact = newValue
         }
     }
     private var redactor: LogRedactor

--- a/Sources/XCLogParser/lexer/Lexer.swift
+++ b/Sources/XCLogParser/lexer/Lexer.swift
@@ -46,16 +46,22 @@ public final class Lexer {
     /// - parameter contents: The contents of the .xcactivitylog
     /// - parameter redacted: If true, the user's directory will be replaced by `<redacted>`
     /// for privacy concerns.
+    /// - parameter withoutBuildSpecificInformation: If true, build specific information will be removed from the logs.
     /// - returns: An array of all the `Token` in the log.
     /// - throws: An error if the document is not a valid SLF document
-    public func tokenize(contents: String, redacted: Bool) throws -> [Token] {
+    public func tokenize(contents: String,
+                         redacted: Bool,
+                         withoutBuildSpecificInformation: Bool) throws -> [Token] {
         let scanner = Scanner(string: contents)
         guard scanSLFHeader(scanner: scanner) else {
             throw XCLogParserError.invalidLogHeader(filePath)
         }
         var tokens = [Token]()
         while !scanner.isAtEnd {
-            guard let logTokens = scanSLFType(scanner: scanner, redacted: redacted), logTokens.isEmpty == false else {
+            guard let logTokens = scanSLFType(scanner: scanner,
+                                              redacted: redacted,
+                                              withoutBuildSpecificInformation: withoutBuildSpecificInformation),
+                logTokens.isEmpty == false else {
                 print(tokens)
                 throw XCLogParserError.invalidLine(scanner.approximateLine)
             }
@@ -73,7 +79,7 @@ public final class Lexer {
         return scanner.scanString(Lexer.SLFHeader, into: &format)
     }
 
-    private func scanSLFType(scanner: Scanner, redacted: Bool) -> [Token]? {
+    private func scanSLFType(scanner: Scanner, redacted: Bool, withoutBuildSpecificInformation: Bool) -> [Token]? {
 
         guard let payload = scanPayload(scanner: scanner) else {
             return nil
@@ -83,7 +89,11 @@ public final class Lexer {
         }
 
         return tokenTypes.compactMap { tokenType -> Token? in
-            scanToken(scanner: scanner, payload: payload, tokenType: tokenType, redacted: redacted)
+            scanToken(scanner: scanner,
+                      payload: payload,
+                      tokenType: tokenType,
+                      redacted: redacted,
+                      withoutBuildSpecificInformation: withoutBuildSpecificInformation)
         }
     }
 
@@ -127,54 +137,102 @@ public final class Lexer {
         return nil
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
-    private func scanToken(scanner: Scanner, payload: String, tokenType: TokenType, redacted: Bool) -> Token? {
+    private func scanToken(scanner: Scanner,
+                           payload: String,
+                           tokenType: TokenType,
+                           redacted: Bool,
+                           withoutBuildSpecificInformation: Bool) -> Token? {
         switch tokenType {
         case .int:
-            guard let value = UInt64(payload) else {
-                print("error parsing int")
-                return nil
-            }
-            return .int(value)
+            return handleIntTokenTypeCase(payload: payload)
         case .className:
-            guard let className = scanString(length: payload, scanner: scanner, redacted: redacted) else {
-                print("error parsing string")
-                return nil
-            }
-            classNames.append(className)
-            return .className(className)
+            return handleClassNameTokenTypeCase(scanner: scanner,
+                                                payload: payload,
+                                                redacted: redacted,
+                                                withoutBuildSpecificInformation: withoutBuildSpecificInformation)
         case .classNameRef:
-            guard let value = Int(payload) else {
-                print("error parsing classNameRef")
-                return nil
-            }
-            let element = value - 1
-            let className = classNames[element]
-            return .classNameRef(className)
+            return handleClassNameRefTokenTypeCase(payload: payload)
         case .string:
-            guard let content = scanString(length: payload, scanner: scanner, redacted: redacted) else {
-                print("error parsing string")
-                return nil
-            }
-            return .string(content)
+            return handleStringTokenTypeCase(scanner: scanner,
+                                             payload: payload,
+                                             redacted: redacted,
+                                             withoutBuildSpecificInformation: withoutBuildSpecificInformation)
         case .double:
-            guard let double = hexToInt(payload) else {
-                print("error parsing double")
-                return nil
-            }
-            return .double(double)
+            return handleDoubleTokenTypeCase(payload: payload)
         case .null:
             return .null
         case .list:
-            guard let value = Int(payload) else {
-                print("error parsing list")
-                return nil
-            }
-            return .list(value)
+            return handleListTokenTypeCase(payload: payload)
         }
     }
 
-    private func scanString(length: String, scanner: Scanner, redacted: Bool) -> String? {
+    private func handleIntTokenTypeCase(payload: String) -> Token? {
+        guard let value = UInt64(payload) else {
+            print("error parsing int")
+            return nil
+        }
+        return .int(value)
+    }
+
+    private func handleClassNameTokenTypeCase(scanner: Scanner,
+                                              payload: String,
+                                              redacted: Bool,
+                                              withoutBuildSpecificInformation: Bool) -> Token? {
+        guard let className = scanString(length: payload,
+                                         scanner: scanner,
+                                         redacted: redacted,
+                                         withoutBuildSpecificInformation: withoutBuildSpecificInformation) else {
+                                            print("error parsing string")
+                                            return nil
+        }
+        classNames.append(className)
+        return .className(className)
+    }
+
+    private func handleClassNameRefTokenTypeCase(payload: String) -> Token? {
+        guard let value = Int(payload) else {
+            print("error parsing classNameRef")
+            return nil
+        }
+        let element = value - 1
+        let className = classNames[element]
+        return .classNameRef(className)
+    }
+
+    private func handleStringTokenTypeCase(scanner: Scanner,
+                                           payload: String,
+                                           redacted: Bool,
+                                           withoutBuildSpecificInformation: Bool) -> Token? {
+        guard let content = scanString(length: payload,
+                                       scanner: scanner,
+                                       redacted: redacted,
+                                       withoutBuildSpecificInformation: withoutBuildSpecificInformation) else {
+                                        print("error parsing string")
+                                        return nil
+        }
+        return .string(content)
+    }
+
+    private func handleDoubleTokenTypeCase(payload: String) -> Token? {
+        guard let double = hexToInt(payload) else {
+            print("error parsing double")
+            return nil
+        }
+        return .double(double)
+    }
+
+    private func handleListTokenTypeCase(payload: String) -> Token? {
+        guard let value = Int(payload) else {
+            print("error parsing list")
+            return nil
+        }
+        return .list(value)
+    }
+
+    private func scanString(length: String,
+                            scanner: Scanner,
+                            redacted: Bool,
+                            withoutBuildSpecificInformation: Bool) -> String? {
         guard let value = Int(length) else {
             print("error parsing string")
             return nil
@@ -187,10 +245,14 @@ public final class Lexer {
         let end = String.Index(encodedOffset: scanner.scanLocation + value)
         #endif
         scanner.scanLocation += value
+        var result = String(scanner.string[start..<end])
         if redacted {
-            return redactor.redactUserDir(string: String(scanner.string[start..<end]))
+            result = redactor.redactUserDir(string: result)
         }
-        return String(scanner.string[start..<end])
+        if withoutBuildSpecificInformation {
+            result = result.removeProductBuildIdentifier()
+        }
+        return result
     }
 
     private func hexToInt(_ input: String) -> Double? {

--- a/Sources/XCLogParserApp/commands/CommonCommand.swift
+++ b/Sources/XCLogParserApp/commands/CommonCommand.swift
@@ -55,6 +55,11 @@ let redactedSwitch = Switch(flag: "r",
                             usage: "Redacts the username of the paths found in the log. " +
     "For instance, /Users/timcook/project will be /Users/<redacted>/project")
 
+let withoutBuildSpecificInformationSwitch = Switch(flag: "w",
+                                                   key: "without_build_specific_information",
+                                                   usage: "Removes build specific information from the logs. " +
+    "For instance, DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build will be DerivedData/Product/Build")
+
 let strictProjectNameSwitch = Switch(key: "strictProjectName",
     usage: "Use strict name testing when trying to find the latest version " +
     "of the project in the DerivedData directory.")

--- a/Sources/XCLogParserApp/commands/DumpCommand.swift
+++ b/Sources/XCLogParserApp/commands/DumpCommand.swift
@@ -48,8 +48,9 @@ struct DumpCommand: CommandProtocol {
                                     xcactivitylogPath: options.logFile,
                                     strictProjectName: options.strictProjectName)
         let actionOptions = ActionOptions(reporter: reporter,
-                                           outputPath: options.output,
-                                           redacted: options.redacted)
+                                          outputPath: options.output,
+                                          redacted: options.redacted,
+                                          withoutBuildSpecificInformation: options.withoutBuildSpecificInformation)
         let action = Action.dump(options: actionOptions)
         let command = Command(logOptions: logOptions, action: action)
         do {
@@ -69,6 +70,7 @@ struct DumpOptions: OptionsProtocol {
     let workspace: String
     let xcodeproj: String
     let redacted: Bool
+    let withoutBuildSpecificInformation: Bool
     let strictProjectName: Bool
     let output: String
 
@@ -78,19 +80,21 @@ struct DumpOptions: OptionsProtocol {
         -> (_ workspace: String)
         -> (_ xcodeproj: String)
         -> (_ redacted: Bool)
+        -> (_ withoutBuildSpecificInformation: Bool)
         -> (_ strictProjectName: Bool)
         -> (_ output: String) -> DumpOptions {
-            return { derivedData in { projectName in { workspace in { xcodeproj in { redacted
-                in { strictProjectName in { output in
+            return { derivedData in { projectName in { workspace in { xcodeproj
+                in { redacted in { withoutBuildSpecificInformation in { strictProjectName in { output in
                     self.init(logFile: logFile,
                               derivedData: derivedData,
                               projectName: projectName,
                               workspace: workspace,
                               xcodeproj: xcodeproj,
                               redacted: redacted,
+                              withoutBuildSpecificInformation: withoutBuildSpecificInformation,
                               strictProjectName: strictProjectName,
                               output: output)
-                }}}}}}}
+                }}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<DumpOptions, CommandantError<CommandantError<Swift.Error>>> {
@@ -101,6 +105,7 @@ struct DumpOptions: OptionsProtocol {
             <*> mode <| workspaceOption
             <*> mode <| xcodeprojOption
             <*> mode <| redactedSwitch
+            <*> mode <| withoutBuildSpecificInformationSwitch
             <*> mode <| strictProjectNameSwitch
             <*> mode <| outputOption
     }

--- a/Sources/XCLogParserApp/commands/ManifestCommand.swift
+++ b/Sources/XCLogParserApp/commands/ManifestCommand.swift
@@ -49,7 +49,8 @@ struct ManifestCommand: CommandProtocol {
                                     strictProjectName: options.strictProjectName)
         let actionOptions = ActionOptions(reporter: reporter,
                                           outputPath: options.output,
-                                          redacted: false)
+                                          redacted: false,
+                                          withoutBuildSpecificInformation: false)
         let action = Action.manifest(options: actionOptions)
         let command = Command(logOptions: logOptions, action: action)
         do {

--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -61,6 +61,7 @@ struct ParseCommand: CommandProtocol {
         let actionOptions = ActionOptions(reporter: reporter,
                                           outputPath: options.output,
                                           redacted: options.redacted,
+                                          withoutBuildSpecificInformation: options.withoutBuildSpecificInformation,
                                           machineName: options.machineName.isEmpty ? nil : options.machineName)
         let action = Action.parse(options: actionOptions)
         let command = Command(logOptions: logOptions, action: action)
@@ -83,6 +84,7 @@ struct ParseOptions: OptionsProtocol {
     let reporter: String
     let machineName: String
     let redacted: Bool
+    let withoutBuildSpecificInformation: Bool
     let strictProjectName: Bool
     let output: String
 
@@ -94,10 +96,11 @@ struct ParseOptions: OptionsProtocol {
         -> (_ reporter: String)
         -> (_ machineName: String)
         -> (_ redacted: Bool)
+        -> (_ withoutBuildSpecificInformation: Bool)
         -> (_ strictProjectName: Bool)
         -> (_ output: String) -> ParseOptions {
             return { derivedData in { projectName in { workspace in { xcodeproj in { reporter in { machineName
-                in { redacted in { strictProjectName in {
+                in { redacted in { withoutBuildSpecificInformation in { strictProjectName in {
             output in
             self.init(logFile: logFile,
                       derivedData: derivedData,
@@ -107,9 +110,10 @@ struct ParseOptions: OptionsProtocol {
                       reporter: reporter,
                       machineName: machineName,
                       redacted: redacted,
+                      withoutBuildSpecificInformation: withoutBuildSpecificInformation,
                       strictProjectName: strictProjectName,
                       output: output)
-                    }}}}}}}}}
+                    }}}}}}}}}}
     }
 
     static func evaluate(_ mode: CommandMode) -> Result<ParseOptions, CommandantError<CommandantError<Swift.Error>>> {
@@ -130,6 +134,7 @@ struct ParseOptions: OptionsProtocol {
                 usage: "Optional. The name of the machine." +
                 "If not specified, the host name will be used.")
             <*> mode <| redactedSwitch
+            <*> mode <| withoutBuildSpecificInformationSwitch
             <*> mode <| strictProjectNameSwitch
             <*> mode <| outputOption
     }

--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -100,8 +100,7 @@ struct ParseOptions: OptionsProtocol {
         -> (_ strictProjectName: Bool)
         -> (_ output: String) -> ParseOptions {
             return { derivedData in { projectName in { workspace in { xcodeproj in { reporter in { machineName
-                in { redacted in { withoutBuildSpecificInformation in { strictProjectName in {
-            output in
+                in { redacted in { withoutBuildSpecificInformation in { strictProjectName in { output in
             self.init(logFile: logFile,
                       derivedData: derivedData,
                       projectName: projectName,

--- a/Tests/XCLogParserTests/LexerTests.swift
+++ b/Tests/XCLogParserTests/LexerTests.swift
@@ -26,7 +26,7 @@ class LexerTests: XCTestCase {
 
     func testTokenizeInt() throws {
         let logContents = "SLF09#"
-        let tokens = try lexer.tokenize(contents: logContents, redacted: false)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: false)
         XCTAssertEqual(1, tokens.count)
         let classNameToken = tokens[0]
         XCTAssertEqual(classNameToken, Token.int(9))
@@ -34,7 +34,7 @@ class LexerTests: XCTestCase {
 
     func testTokenizeClassName() throws {
         let logContents = "SLF09#21%IDEActivityLogSection"
-        let tokens = try lexer.tokenize(contents: logContents, redacted: false)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: false)
         XCTAssertEqual(2, tokens.count)
         let classNameToken = tokens[1]
         XCTAssertEqual(classNameToken, Token.className("IDEActivityLogSection"))
@@ -42,7 +42,7 @@ class LexerTests: XCTestCase {
 
     func testTokenizeClassNameRef() throws {
         let logContents = "SLF09#21%IDEActivityLogSection1@"
-        let tokens = try lexer.tokenize(contents: logContents, redacted: false)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: false)
         XCTAssertTrue(tokens.count == 3)
         let classNameReferenceToken = tokens[2]
         XCTAssertEqual(classNameReferenceToken, Token.classNameRef("IDEActivityLogSection"))
@@ -50,7 +50,7 @@ class LexerTests: XCTestCase {
 
     func testTokenizeString() throws {
         let logContents = "SLF09#21%IDEActivityLogSection1@39\"Xcode.IDEActivityLogDomainType.BuildLog"
-        let tokens = try lexer.tokenize(contents: logContents, redacted: false)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: false)
         XCTAssertTrue(tokens.count == 4)
         let stringToken = tokens[3]
         XCTAssertEqual(stringToken, Token.string("Xcode.IDEActivityLogDomainType.BuildLog"))
@@ -58,7 +58,7 @@ class LexerTests: XCTestCase {
 
     func testTokenizeDouble() throws {
         let logContents = "SLF09#21%IDEActivityLogSection1@39\"Xcode.IDEActivityLogDomainType.BuildLog356098f239dfc041^"
-        let tokens = try lexer.tokenize(contents: logContents, redacted: false)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: false)
         XCTAssertTrue(tokens.count == 5)
         let doubleToken = tokens[4]
         XCTAssertEqual(doubleToken, Token.double(566129637.19043601))
@@ -67,7 +67,7 @@ class LexerTests: XCTestCase {
     func testTokenizeListNil() throws {
         let logContents = "SLF09#21%IDEActivityLogSection1" +
                           "@39\"Xcode.IDEActivityLogDomainType.BuildLog356098f239dfc041^-"
-        let tokens = try lexer.tokenize(contents: logContents, redacted: false)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: false)
         XCTAssertTrue(tokens.count == 6)
         let nilToken = tokens[5]
         XCTAssertEqual(nilToken, Token.null)
@@ -76,7 +76,7 @@ class LexerTests: XCTestCase {
     func testTokenizeList() throws {
         let logContents = "SLF09#21%IDEActivityLogSection1" +
                             "@39\"Xcode.IDEActivityLogDomainType.BuildLog356098f239dfc041^-242("
-        let tokens = try lexer.tokenize(contents: logContents, redacted: false)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: false)
         XCTAssertTrue(tokens.count == 7)
         let listToken = tokens[6]
         XCTAssertEqual(listToken, Token.list(242))
@@ -86,23 +86,56 @@ class LexerTests: XCTestCase {
         // `=` is not a valid token identifier, we should throw an error
         let logContents = "SLF09#21%IDEActivityLogSection1" +
         "@39\"Xcode.IDEActivityLogDomainType.BuildLog356098f239dfc041^-242="
-        XCTAssertThrowsError(try lexer.tokenize(contents: logContents, redacted: false))
+        XCTAssertThrowsError(try lexer.tokenize(contents: logContents,
+                                                redacted: false,
+                                                withoutBuildSpecificInformation: false))
     }
 
     func testTokenizeStringWithTokenDelimiters() throws {
         let logContents = "SLF09#21%IDEActivityLogSection1" +
         "@38\"##Xcode.IDEActivityLogDomainType.Build356098f239dfc0^-242("
-        let tokens = try lexer.tokenize(contents: logContents, redacted: false)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: false)
         XCTAssertTrue(tokens.count == 7)
 
     }
 
     func testTokenizeStringRedacted() throws {
         let logContents = "SLF09#21%IDEActivityLogSection1@36\"Compile /Users/myuser/project/File.m"
-        let tokens = try lexer.tokenize(contents: logContents, redacted: true)
+        let tokens = try lexer.tokenize(contents: logContents, redacted: true, withoutBuildSpecificInformation: false)
         XCTAssertTrue(tokens.count == 4)
         let stringToken = tokens[3]
         XCTAssertEqual(stringToken, Token.string("Compile /Users/<redacted>/project/File.m"))
     }
 
+    func testTokenizeStringWithoutBuildSpecificInformation() throws {
+        let logContents = "SLF09#21%IDEActivityLogSection1@346\"/Applications/Xcode.app/Contents/Developer/" +
+            "Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/myuser/Library/Developer/Xcode/" +
+            "DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build/Intermediates.noindex/Product.build/" +
+            "Debug-iphonesimulator/Library.build/Objects-normal/x86_64/Object.o is not an object file" +
+        " (not allowed in a library)"
+
+        let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: true)
+        XCTAssertTrue(tokens.count == 4)
+        let stringToken = tokens[3]
+        XCTAssertEqual(stringToken, Token.string("/Applications/Xcode.app/Contents/Developer/Toolchains/" +
+            "XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/myuser/Library/Developer/Xcode/" +
+            "DerivedData/Product/Build/Intermediates.noindex/Product.build/Debug-iphonesimulator/" +
+            "Library.build/Objects-normal/x86_64/Object.o is not an object file (not allowed in a library)"))
+    }
+
+    func testTokenizeStringRedactedAndWithoutBuildSpecificInformation() throws {
+        let logContents = "SLF09#21%IDEActivityLogSection1@346\"/Applications/Xcode.app/Contents/Developer/" +
+            "Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/myuser/Library/Developer/Xcode/" +
+            "DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build/Intermediates.noindex/Product.build/" +
+            "Debug-iphonesimulator/Library.build/Objects-normal/x86_64/Object.o is not an object file" +
+        " (not allowed in a library)"
+
+        let tokens = try lexer.tokenize(contents: logContents, redacted: true, withoutBuildSpecificInformation: true)
+        XCTAssertTrue(tokens.count == 4)
+        let stringToken = tokens[3]
+        XCTAssertEqual(stringToken, Token.string("/Applications/Xcode.app/Contents/Developer/Toolchains/" +
+            "XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/<redacted>/Library/Developer/Xcode/" +
+            "DerivedData/Product/Build/Intermediates.noindex/Product.build/Debug-iphonesimulator/" +
+            "Library.build/Objects-normal/x86_64/Object.o is not an object file (not allowed in a library)"))
+    }
 }


### PR DESCRIPTION
### What?

* Integrates removing build specific information into XCLogParser tool. The option is available for `parse` and `dump` commands under `--without_build_specific_information` or `-w` flag.
* Fixes 2 SwiftLint warnings as mentioned [here](https://github.com/spotify/XCLogParser/pull/97#pullrequestreview-476730979).

### Why?

Sometimes logs contain build specific information, such us build identifier `Product-bolnckhlbzxpxoeyfujluasoupft`:

```
libtool: file: /Users/user/Library/Developer/Xcode/DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build/Intermediates.noindex/Product.build/Debug-iphonesimulator/external_SwiftLibrary.build/Objects-normal/x86_64/Object.o is not an object file (not allowed in a library)
```

This becomes problematic when you want to group log messages by its content in order to see how often they occur. Removing such build specific information enables such grouping.