### PR TITLE
Fixes swift debug parsing for projects with spaces in file paths

### DIFF
--- a/Sources/XCLogParser/parser/SwiftCompilerParser.swift
+++ b/Sources/XCLogParser/parser/SwiftCompilerParser.swift
@@ -74,11 +74,21 @@ public class SwiftCompilerParser {
     }
 
     public func findFunctionTimesForFilePath(_ filePath: String) -> [SwiftFunctionTime]? {
-        return functionsPerFile?[filePath]
+        // File paths found in IDEActivityLogSection.text are unescaped
+        // so percent encoding needs to be removed from filePath
+        guard let unescapedFilePath = filePath.removingPercentEncoding else {
+            return nil
+        }
+        return functionsPerFile?[unescapedFilePath]
     }
 
     public func findTypeChecksForFilePath(_ filePath: String) -> [SwiftTypeCheck]? {
-        return typeChecksPerFile?[filePath]
+        // File paths found in IDEActivityLogSection.text are unescaped
+         // so percent encoding needs to be removed from filePath
+        guard let unescapedFilePath = filePath.removingPercentEncoding else {
+            return nil
+        }
+        return typeChecksPerFile?[unescapedFilePath]
     }
 
     public func hasFunctionTimes() -> Bool {


### PR DESCRIPTION
There's a bug right now where file paths in `BuildSteps` are escaped, while file paths in `IDEActivityLogSection` are not. This PR updates `SwiftCompilerParser` to unescape filePaths before checking to see that file has swift functions and type checks 