### PR TITLE
Add possibility to remove hexadecimal numbers from log

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.18"
+    public static let current = "0.2.19"
 
 }

--- a/Sources/XCLogParser/lexer/Lexer.swift
+++ b/Sources/XCLogParser/lexer/Lexer.swift
@@ -250,7 +250,9 @@ public final class Lexer {
             result = redactor.redactUserDir(string: result)
         }
         if withoutBuildSpecificInformation {
-            result = result.removeProductBuildIdentifier()
+            result = result
+                .removeProductBuildIdentifier()
+                .removeHexadecimalNumbers()
         }
         return result
     }

--- a/Sources/XCLogParser/lexer/String+BuildSpecificInformationRemoval.swift
+++ b/Sources/XCLogParser/lexer/String+BuildSpecificInformationRemoval.swift
@@ -44,4 +44,25 @@ extension String {
             return self
         }
     }
+
+    /// Removes hexadecimal numbers from the log and puts `<hexadecimal_number>` instead.
+    ///
+    /// Example: "NSUnderlyingError=0x7fcdc8712290" becomes "NSUnderlyingError=<hexadecimal_number>".
+    func removeHexadecimalNumbers() -> String {
+        do {
+            var mutableSelf = self
+            let regularExpression = try NSRegularExpression(pattern: "0[xX][0-9a-fA-F]+")
+            regularExpression.enumerateMatches(in: self,
+                                               options: [],
+                                               range: NSRange(location: 0, length: count)) { match, _, _ in
+                if let match = match {
+                    let hexadecimalNumber = self.substring(match.range(at: 0))
+                    mutableSelf = mutableSelf.replacingOccurrences(of: hexadecimalNumber, with: "<hexadecimal_number>")
+                }
+            }
+            return mutableSelf
+        } catch {
+            return self
+        }
+    }
 }

--- a/Tests/XCLogParserTests/LexerTests.swift
+++ b/Tests/XCLogParserTests/LexerTests.swift
@@ -108,11 +108,11 @@ class LexerTests: XCTestCase {
     }
 
     func testTokenizeStringWithoutBuildSpecificInformation() throws {
-        let logContents = "SLF09#21%IDEActivityLogSection1@346\"/Applications/Xcode.app/Contents/Developer/" +
+        let logContents = "SLF09#21%IDEActivityLogSection1@385\"/Applications/Xcode.app/Contents/Developer/" +
             "Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/myuser/Library/Developer/Xcode/" +
             "DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build/Intermediates.noindex/Product.build/" +
             "Debug-iphonesimulator/Library.build/Objects-normal/x86_64/Object.o is not an object file" +
-        " (not allowed in a library)"
+        " (not allowed in a library) some hexadecimal number 0x7fcdc8712290"
 
         let tokens = try lexer.tokenize(contents: logContents, redacted: false, withoutBuildSpecificInformation: true)
         XCTAssertTrue(tokens.count == 4)
@@ -120,15 +120,16 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(stringToken, Token.string("/Applications/Xcode.app/Contents/Developer/Toolchains/" +
             "XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/myuser/Library/Developer/Xcode/" +
             "DerivedData/Product/Build/Intermediates.noindex/Product.build/Debug-iphonesimulator/" +
-            "Library.build/Objects-normal/x86_64/Object.o is not an object file (not allowed in a library)"))
+            "Library.build/Objects-normal/x86_64/Object.o is not an object file (not allowed in a library) " +
+            "some hexadecimal number <hexadecimal_number>"))
     }
 
     func testTokenizeStringRedactedAndWithoutBuildSpecificInformation() throws {
-        let logContents = "SLF09#21%IDEActivityLogSection1@346\"/Applications/Xcode.app/Contents/Developer/" +
+        let logContents = "SLF09#21%IDEActivityLogSection1@385\"/Applications/Xcode.app/Contents/Developer/" +
             "Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/myuser/Library/Developer/Xcode/" +
             "DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build/Intermediates.noindex/Product.build/" +
             "Debug-iphonesimulator/Library.build/Objects-normal/x86_64/Object.o is not an object file" +
-        " (not allowed in a library)"
+        " (not allowed in a library) some hexadecimal number 0x7fcdc8712290"
 
         let tokens = try lexer.tokenize(contents: logContents, redacted: true, withoutBuildSpecificInformation: true)
         XCTAssertTrue(tokens.count == 4)
@@ -136,6 +137,7 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(stringToken, Token.string("/Applications/Xcode.app/Contents/Developer/Toolchains/" +
             "XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/<redacted>/Library/Developer/Xcode/" +
             "DerivedData/Product/Build/Intermediates.noindex/Product.build/Debug-iphonesimulator/" +
-            "Library.build/Objects-normal/x86_64/Object.o is not an object file (not allowed in a library)"))
+            "Library.build/Objects-normal/x86_64/Object.o is not an object file (not allowed in a library) " +
+            "some hexadecimal number <hexadecimal_number>"))
     }
 }

--- a/Tests/XCLogParserTests/String+BuildSpecificInformationRemovalTests.swift
+++ b/Tests/XCLogParserTests/String+BuildSpecificInformationRemovalTests.swift
@@ -54,4 +54,45 @@ final class StringBuildSpecificInformationRemovalTest: XCTestCase {
 
         XCTAssertEqual(result, log)
     }
+
+    func testRemoveHexadecimalNumbersWithLogContainingHexadecimalNumberRemovesHexadecimalNumber() {
+        let log = """
+        UserInfo={NSUnderlyingError=0x7fcdc8712290 {Error Domain=kCFErrorDomainCFNetwork Code=-1003 "(null)"
+        UserInfo={_kCFStreamErrorCodeKey=8, _kCFStreamErrorDomainKey=12}}
+        """
+
+        let result = log.removeHexadecimalNumbers()
+
+        XCTAssertEqual(result, """
+        UserInfo={NSUnderlyingError=<hexadecimal_number> {Error Domain=kCFErrorDomainCFNetwork Code=-1003 \"(null)\"
+        UserInfo={_kCFStreamErrorCodeKey=8, _kCFStreamErrorDomainKey=12}}
+        """)
+    }
+
+    func testRemoveHexadecimalNumbersWithLogContainingMultipleHexadecimalNumbersRemovesAllOfThem() {
+        let log = """
+        {NSUnderlyingError=0x7fb6d57290c0 {Error Domain=kCFErrorDomainCFNetwork Code=-1005 "(null)"
+        UserInfo={NSErrorPeerAddressKey=<CFData 0x7fb6d562c810 [0x7fffa8cc28e0]>{length = 16, capacity = 16,
+        bytes = 0x100200500aad1b7e0000000000000000}
+        """
+
+        let result = log.removeHexadecimalNumbers()
+
+        XCTAssertEqual(result, """
+        {NSUnderlyingError=<hexadecimal_number> {Error Domain=kCFErrorDomainCFNetwork Code=-1005 "(null)"
+        UserInfo={NSErrorPeerAddressKey=<CFData <hexadecimal_number> [<hexadecimal_number>]>{length = 16, capacity = 16,
+        bytes = <hexadecimal_number>}
+        """)
+    }
+
+    func testRemoveHexadecimalNumbersWithLogNotContainingHexadecimalNumbersIsNoop() {
+        let log = """
+        UserInfo={NSUnderlyingError=7fcdc8712290 {Error Domain=kCFErrorDomainCFNetwork Code=-1003 \"(null)\"
+        UserInfo={_kCFStreamErrorCodeKey=8, _kCFStreamErrorDomainKey=12}}
+        """
+
+        let result = log.removeHexadecimalNumbers()
+
+        XCTAssertEqual(result, log)
+    }
 }


### PR DESCRIPTION
### What?

Adds possibility to remove hexadecimal numbers from the log.

### Why?

Sometimes logs contain build specific information, such us hexadecimal numbers (mostly object addresses) like in `NSUnderlyingError=0x7fcdc8712290`:

```
{NSUnderlyingError=0x7fcdc8712290 {Error Domain=kCFErrorDomainCFNetwork Code=-1003 "(null)" UserInfo={_kCFStreamErrorCodeKey=8, _kCFStreamErrorDomainKey=12}}}
```

This becomes problematic when you want to group log messages by its content in order to see how often they occur. Removing build specific information enables such grouping.