### PR TITLE
Fixes logic with swiftc parsing

### DIFF
--- a/Sources/XCLogParser/parser/SwiftCompilerParser.swift
+++ b/Sources/XCLogParser/parser/SwiftCompilerParser.swift
@@ -63,6 +63,7 @@ public class SwiftCompilerParser {
                 textsAndOccurrences[rawFunctionTimes] = outputOccurrence
             }
         }
+        print("done with findRawSwiftTimes")
         return textsAndOccurrences
     }
 

--- a/Sources/XCLogParser/parser/SwiftCompilerParser.swift
+++ b/Sources/XCLogParser/parser/SwiftCompilerParser.swift
@@ -63,7 +63,6 @@ public class SwiftCompilerParser {
                 textsAndOccurrences[rawFunctionTimes] = outputOccurrence
             }
         }
-        print("done with findRawSwiftTimes")
         return textsAndOccurrences
     }
 

--- a/Sources/XCLogParser/parser/SwiftCompilerTimeOptionParser.swift
+++ b/Sources/XCLogParser/parser/SwiftCompilerTimeOptionParser.swift
@@ -38,12 +38,31 @@ protocol SwiftCompilerTimeOptionParser {
 
 extension SwiftCompilerTimeOptionParser {
 
-    func isInvalid(fileName: String) -> Bool {
-        return fileName == "<invalid loc>"
+    /// Parses /users/spotify/project/SomeFile.swift:10:12
+    /// - Returns: ("file:///users/spotify/project/SomeFile.swift", 10, 12)
+    func parseNameAndLocation(from fileAndLocation: String) -> (String, Int, Int)? {
+        // /users/spotify/project/SomeFile.swift:10:12
+        let fileAndLocationParts = fileAndLocation.components(separatedBy: ":")
+        let rawFile = fileAndLocationParts[0]
+
+        guard rawFile != "<invalid loc>" else {
+            return nil
+        }
+
+        guard fileAndLocationParts.count == 3 else {
+            return nil
+        }
+
+        let file = prefixWithFileURL(fileName: rawFile)
+        let line = Int(fileAndLocationParts[1])!
+        let column = Int(fileAndLocationParts[2])!
+
+        return (file, line, column)
     }
 
+    /// Parses
     func parseCompileDuration(_ durationString: String) -> Double {
-        if let duration = Double(durationString) {
+        if let duration = Double(durationString.replacingOccurrences(of: "ms", with: "")) {
             return duration
         }
         return 0.0

--- a/Sources/XCLogParser/parser/SwiftCompilerTimeOptionParser.swift
+++ b/Sources/XCLogParser/parser/SwiftCompilerTimeOptionParser.swift
@@ -40,6 +40,7 @@ extension SwiftCompilerTimeOptionParser {
 
     /// Parses /users/spotify/project/SomeFile.swift:10:12
     /// - Returns: ("file:///users/spotify/project/SomeFile.swift", 10, 12)
+    // swiftlint:disable:next large_tuple
     func parseNameAndLocation(from fileAndLocation: String) -> (String, Int, Int)? {
         // /users/spotify/project/SomeFile.swift:10:12
         let fileAndLocationParts = fileAndLocation.components(separatedBy: ":")

--- a/Tests/XCLogParserTests/SwiftCompilerParserTests.swift
+++ b/Tests/XCLogParserTests/SwiftCompilerParserTests.swift
@@ -36,9 +36,9 @@ class SwiftCompilerParserTests: XCTestCase {
         let emptylogSection = getFakeSwiftcSection(text: "text",
                                               commandDescription: "command")
         let text =
-        "\t0.05ms\t/Users/user/\(rawFile).swift:9:9\tgetter textLabel\r" +
-        "\t4.96ms\t/Users/user/\(rawFile).swift:11:14\tinitializer init(frame:)\r" +
-        "\t0.04ms\t<invalid loc>\tgetter None\r"
+        "0.05ms\t/Users/user/\(rawFile).swift:9:9\tgetter textLabel\r" +
+        "4.96ms\t/Users/user/\(rawFile).swift:11:14\tinitializer init(frame:)\r" +
+        "0.04ms\t<invalid loc>\tgetter None\r"
         let swiftTimesLogSection = getFakeSwiftcSection(text:
             text, commandDescription: "-debug-time-function-bodies")
 
@@ -82,11 +82,11 @@ class SwiftCompilerParserTests: XCTestCase {
                                               commandDescription: "command")
 
         let swiftTimesLogSection = getFakeSwiftcSection(text:
-            "\t0.72ms\t/Users/\(rawFile).swift:19:15\r",
+            "0.72ms\t/Users/\(rawFile).swift:19:15\r",
         commandDescription: "-debug-time-expression-type-checking")
 
         let duplicatedSwiftTimeslogSection = getFakeSwiftcSection(text:
-            "\t0.72ms\t/Users/\(rawFile).swift:19:15\r",
+            "0.72ms\t/Users/\(rawFile).swift:19:15\r",
         commandDescription: "-debug-time-expression-type-checking")
         let expectedFile = "file:///Users/\(escapedFile).swift"
         parser.addLogSection(emptylogSection)


### PR DESCRIPTION
Noticed there were missing `swiftFunctionTimes` and `swiftTypeCheckTimes` in the outputted json report that were in the original `xcactivitylog`. After some investigation, it looks like the regex parsing used has some bugs. When running through the matches in the `parse(command:occurrences:)` methods, there were results that had multiple entries included in them and then were skipped:
```
“\r2.66ms\t/Users/user/workspace/project/directory/Utils/Utils/Validator/TextValidator.swift:61:71\r1.54ms\t/Users/user/workspace/project/directory/Utils/Utils/Validator/TextValidator.swift:62:63\r”
```
It may be caused by the trailing `+(.+)\\r` in regex queries, which is a bit indeterministic and in some cases may include a `\r` in it. Had some issues getting a regex query that worked correctly, so moved to just splitting `commands` on `\r` and `\t`. Didn't do a ton of benchmarking, but it didn't seem to cause the script to run noticeably slower. For reference the project I
m running on is fairly large with well over 10k files.

Total transparency, I'm new to `xcactivitylog` files so I assume this is a bug, but let me know otherwise!



