### PR TITLE
Avoid having duplicated Swift errors reported

### DIFF
--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -66,7 +66,8 @@ extension Notice {
                     if noticeDetail.starts(with: "error:") == false {
                         var errorLocation = notice.documentURL.replacingOccurrences(of: "file://", with: "")
                         errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
-                        // do not report error in a file that it does not belong to (we'll ended up having duplicated errors)
+                        // do not report error in a file that it does not belong to (we'll ended
+                        // up having duplicated errors)
                         if logSection.location.documentURLString != notice.documentURL {
                             return nil
                         }

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -66,6 +66,10 @@ extension Notice {
                     if noticeDetail.starts(with: "error:") == false {
                         var errorLocation = notice.documentURL.replacingOccurrences(of: "file://", with: "")
                         errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
+                        // do not report error in a file that it does not belong to (we'll ended up having duplicated errors)
+                        if logSection.location.documentURLString != notice.documentURL {
+                            return nil
+                        }
                         notice = notice.with(detail: swiftErrorDetails[errorLocation])
                     }
                 }


### PR DESCRIPTION
Solves a bug where we were reporting the same Swift error more than once, the right one attributed to the file that originated it and the same error with the wrong attributed file.

cc @BalestraPatrick @polac24 @aleksandergrzyb 