### PR TITLE
Generate pre computed HTML report

### DIFF
--- a/Resources/index.html
+++ b/Resources/index.html
@@ -326,6 +326,6 @@
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.23.0/moment-with-locales.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
-    <script type="text/javascript" src="js/{{app_file}}"></script>
+  <script type="text/javascript" src="js/{{app_file}}"></script>
 </body>
 </html>

--- a/Resources/index.html
+++ b/Resources/index.html
@@ -320,10 +320,12 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.1.2/handlebars.min.js"></script>
-  <script type="text/javascript" src="js/build.js"></script>
+  <script type="text/javascript" src="js/{{data_file}}"></script>
+  <script type="text/javascript" src="js/errors_warnings.js"></script>
+  <script type="text/javascript" src="js/top_files.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.23.0/moment-with-locales.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
-  <script type="text/javascript" src="js/app.js"></script>
+    <script type="text/javascript" src="js/{{app_file}}"></script>
 </body>
 </html>

--- a/Resources/js/app.js
+++ b/Resources/js/app.js
@@ -31,82 +31,82 @@ const swiftCompilation = 'swiftCompilation';
 const cCompilation = 'cCompilation'
 
 const incidentSource = "<details>" +
-  "<summary><span class='font-weight-bold'>{{count}}</span>{{summary}}</summary>" +
-  "<p class='bg-light'>" +
-  "<ul>" +
-  "{{#each details}}" +
-  "{{#if documentURL}}" +
-  "<li>{{clangWarning}} {{title}} " +
-  "In <a href='{{documentURL}}'>{{documentURL}}</a> Line {{startingLineNumber}} column {{startingColumnNumber}}</li>" +
-  "{{else}}" +
-  "<li>{{clangWarning}} {{title}}</li>" +
-  "{{/if}}" +
-  "{{/each}}" +
-  "</ul>" +
-  "</p>" +
-  "</details>";
+    "<summary><span class='font-weight-bold'>{{count}}</span>{{summary}}</summary>" +
+    "<p class='bg-light'>" +
+    "<ul>" +
+    "{{#each details}}" +
+    "{{#if documentURL}}" +
+    "<li>{{clangWarning}} {{title}} " +
+    "In <a href='{{documentURL}}'>{{documentURL}}</a> Line {{startingLineNumber}} column {{startingColumnNumber}}</li>" +
+    "{{else}}" +
+    "<li>{{clangWarning}} {{title}}</li>" +
+    "{{/if}}" +
+    "{{/each}}" +
+    "</ul>" +
+    "</p>" +
+    "</details>";
 
 const incidentTemplate = Handlebars.compile(incidentSource);
 
 const swiftFunctionSource = "<table id='swift-functions-table' class='display table table-sm table-hover table-responsive table-striped'>" +
-  "<thead>" +
-  "<tr>" +
-  "<th scope='col'>Duration (ms)</th>" +
-  "<th scope='col'>File</th>" +
-  "<th scope='col'>Function</th>" +
-  "<th scope='col'>Line</th>" +
-  "<th scope='col'>Column</th>" +
-  "<th scope='col'>Occurrences</th>" +
-  "<th scope='col'>Cumulative (ms)</th>" +
-  "</tr>" +
-  "</thead>" +
-  "{{#each functions}}" +
-  "<tr>" +
-  "<th scope='col'>{{durationMS}}</th>" +
-  "<th scope='col'>{{file}}</th>" +
-  "<th scope='col'>{{signature}}</th>" +
-  "<th scope='col'>{{startingLine}}</th>" +
-  "<th scope='col'>{{startingColumn}}</th>" +
-  "<th scope='col'>{{occurrences}}</th>" +
-  "<th scope='col'>{{cumulative}}</th>" +
-  "</tr>" +
-  "{{/each}}" +
-  "</table>";
+    "<thead>" +
+    "<tr>" +
+    "<th scope='col'>Duration (ms)</th>" +
+    "<th scope='col'>File</th>" +
+    "<th scope='col'>Function</th>" +
+    "<th scope='col'>Line</th>" +
+    "<th scope='col'>Column</th>" +
+    "<th scope='col'>Occurrences</th>" +
+    "<th scope='col'>Cumulative (ms)</th>" +
+    "</tr>" +
+    "</thead>" +
+    "{{#each functions}}" +
+    "<tr>" +
+    "<th scope='col'>{{durationMS}}</th>" +
+    "<th scope='col'>{{file}}</th>" +
+    "<th scope='col'>{{signature}}</th>" +
+    "<th scope='col'>{{startingLine}}</th>" +
+    "<th scope='col'>{{startingColumn}}</th>" +
+    "<th scope='col'>{{occurrences}}</th>" +
+    "<th scope='col'>{{cumulative}}</th>" +
+    "</tr>" +
+    "{{/each}}" +
+    "</table>";
 
 const swiftTypeCheckSource = "<table id='swift-typechecks-table' class='table table-sm table-hover table-responsive table-striped'>" +
-  "<thead>" +
-  "<tr>" +
-  "<th scope='col'>Duration (ms)</th>" +
-  "<th scope='col'>File</th>" +
-  "<th scope='col'>Line</th>" +
-  "<th scope='col'>Column</th>" +
-  "<th scope='col'>Occurrences</th>" +
-  "<th scope='col'>Cumulative (ms)</th>" +
-  "</tr>" +
-  "</thead>" +
-  "{{#each functions}}" +
-  "<tr>" +
-  "<th scope='col'>{{durationMS}}</th>" +
-  "<th scope='col'>{{file}}</th>" +
-  "<th scope='col'>{{startingLine}}</th>" +
-  "<th scope='col'>{{startingColumn}}</th>" +
-  "<th scope='col'>{{occurrences}}</th>" +
-  "<th scope='col'>{{cumulative}}</th>" +
-  "</tr>" +
-  "{{/each}}" +
-  "</table>";
+    "<thead>" +
+    "<tr>" +
+    "<th scope='col'>Duration (ms)</th>" +
+    "<th scope='col'>File</th>" +
+    "<th scope='col'>Line</th>" +
+    "<th scope='col'>Column</th>" +
+    "<th scope='col'>Occurrences</th>" +
+    "<th scope='col'>Cumulative (ms)</th>" +
+    "</tr>" +
+    "</thead>" +
+    "{{#each functions}}" +
+    "<tr>" +
+    "<th scope='col'>{{durationMS}}</th>" +
+    "<th scope='col'>{{file}}</th>" +
+    "<th scope='col'>{{startingLine}}</th>" +
+    "<th scope='col'>{{startingColumn}}</th>" +
+    "<th scope='col'>{{occurrences}}</th>" +
+    "<th scope='col'>{{cumulative}}</th>" +
+    "</tr>" +
+    "{{/each}}" +
+    "</table>";
 
 const swiftFunctionWarning = "<div class='callout callout-warning'>" +
-"<small class='text-muted'>Warning: No Swift function compilation times were found.</small>" +
-"<br>" +
-"Did you compile your project with the flags -Xfrontend -debug-time-function-bodies?" +
-"</div>";
+    "<small class='text-muted'>Warning: No Swift function compilation times were found.</small>" +
+    "<br>" +
+    "Did you compile your project with the flags -Xfrontend -debug-time-function-bodies?" +
+    "</div>";
 
 const swiftTypeCheckWarning = "<div class='callout callout-warning'>" +
-"<small class='text-muted'>Warning: No Swiftc type checks times were found.</small>" +
-"<br>" +
-"Did you compile your project with the flags -Xfrontend -debug-time-expression-type-checking?" +
-"</div>";
+    "<small class='text-muted'>Warning: No Swiftc type checks times were found.</small>" +
+    "<br>" +
+    "Did you compile your project with the flags -Xfrontend -debug-time-expression-type-checking?" +
+    "</div>";
 
 const swiftFunctionTemplate = Handlebars.compile(swiftFunctionSource);
 
@@ -115,493 +115,504 @@ const swiftTypeCheckTemplate = Handlebars.compile(swiftTypeCheckSource);
 drawCharts();
 
 function drawCharts() {
-  const target = getRequestedTarget();
-  if (target === 'main') {
-    loadMainData();
-  } else {
-    loadTargetData(target);
-  }
-  drawHeaders(target);
-  drawErrors(target);
-  drawWarnings(target);
-  drawTimeline();
-  drawSlowestTargets(target);
+    const target = getRequestedTarget();
+    if (target === 'main') {
+        loadMainData();
+    } else {
+        loadTargetData(target);
+    }
+    drawHeaders(target);
+    drawErrors(target);
+    drawWarnings(target);
+    drawTimeline(target);
+    drawSlowestTargets(target);
 
-  if (target === 'main') {
-    document.getElementById('files-row').style.display = 'flex';
-    drawSlowestFiles(cFiles, '#top_cfiles');
-    drawSlowestFiles(swiftFiles, '#top_swiftfiles');
-  } else {
-    document.getElementById('files-row').style.display = 'none';
-  }
-  drawSwiftFunctions(target);
-  drawSwiftTypeChecks(target);
+    if (target === 'main') {
+        document.getElementById('files-row').style.display = 'flex';
+        drawSlowestFiles(cSlowestFiles, '#top_cfiles', target);
+        drawSlowestFiles(swiftSlowestFiles, '#top_swiftfiles', target);
+    } else {
+        document.getElementById('files-row').style.display = 'none';
+    }
+    drawSwiftFunctions(target);
+    drawSwiftTypeChecks(target);
 }
 
 function drawHeaders(target) {
-  setBuildStatus();
-  document.getElementById('build-info').innerHTML = getBuildInfo();
-  if (target === 'main') {
-    document.getElementById('schema-title').innerHTML = 'Schema';
-    document.getElementById('schema').innerHTML = mainStep.schema;
-    document.getElementById('targets-title').innerHTML = 'Targets';
-  } else {
-    document.getElementById('schema-title').innerHTML = 'Target';
-    document.getElementById('schema').innerHTML = mainStep.title.replace('Build target', '');
-    document.getElementById('targets-title').innerHTML = 'Files';
-  }
-  const status = mainStep.buildStatus.charAt(0).toUpperCase() + mainStep.buildStatus.slice(1);
-  document.getElementById('build-status').innerHTML = status;
-  const duration = moment.duration(mainStep.duration * 1000);
-  var durationText = '';
-  if (duration.hours() > 0) {
-    durationText += duration.hours() + ' hrs, ';
-  }
-  if (duration.minutes() > 0) {
-    durationText += duration.minutes() + ' mins, ';
-  }
-  durationText += Math.round(duration.seconds()) + ' secs';
-  document.getElementById('build-time').innerHTML = durationText;
-  document.getElementById('targets').innerHTML = targets.length.toLocaleString('en');
-  const cCompiledFiles = cFiles.filter(function (file) {
-    return file.fetchedFromCache == false;
-  })
-  const swiftCompiledFiles = swiftFiles.filter(function (file) {
-    return file.fetchedFromCache == false;
-  })
-  document.getElementById('c-files-total').innerHTML = cFiles.length.toLocaleString('en') + ' total';
-  document.getElementById('swift-files-total').innerHTML = swiftFiles.length.toLocaleString('en') + ' total';
+    setBuildStatus();
+    document.getElementById('build-info').innerHTML = getBuildInfo();
+    if (target === 'main') {
+        document.getElementById('schema-title').innerHTML = 'Schema';
+        document.getElementById('schema').innerHTML = mainStep.schema;
+        document.getElementById('targets-title').innerHTML = 'Targets';
+    } else {
+        document.getElementById('schema-title').innerHTML = 'Target';
+        document.getElementById('schema').innerHTML = mainStep.title.replace('Build target', '');
+        document.getElementById('targets-title').innerHTML = 'Files';
+    }
+    const status = mainStep.buildStatus.charAt(0).toUpperCase() + mainStep.buildStatus.slice(1);
+    document.getElementById('build-status').innerHTML = status;
+    const duration = moment.duration(mainStep.duration * 1000);
+    var durationText = '';
+    if (duration.hours() > 0) {
+        durationText += duration.hours() + ' hrs, ';
+    }
+    if (duration.minutes() > 0) {
+        durationText += duration.minutes() + ' mins, ';
+    }
+    durationText += Math.round(duration.seconds()) + ' secs';
+    document.getElementById('build-time').innerHTML = durationText;
+    document.getElementById('targets').innerHTML = targets.length.toLocaleString('en');
+
+    document.getElementById('c-files-total').innerHTML = cFiles.length.toLocaleString('en') + ' total';
+    document.getElementById('swift-files-total').innerHTML = swiftFiles.length.toLocaleString('en') + ' total';
 
 }
 
 function setBuildStatus() {
-  const status = mainStep.buildStatus.charAt(0).toUpperCase() + mainStep.buildStatus.slice(1);
-  const statusBox = document.getElementById('status-box');
-  if (status.toLowerCase() === 'succeeded') {
-    statusBox.classList.add('bg-success');
-  } else if (status.toLowerCase().includes('failed') || status.toLowerCase().includes('errors')) {
-    statusBox.classList.add('bg-danger');
-  } else {
-    statusBox.classList.add('bg-warning');
-  }
+    const status = mainStep.buildStatus.charAt(0).toUpperCase() + mainStep.buildStatus.slice(1);
+    const statusBox = document.getElementById('status-box');
+    if (status.toLowerCase() === 'succeeded') {
+        statusBox.classList.add('bg-success');
+    } else if (status.toLowerCase().includes('failed') || status.toLowerCase().includes('errors')) {
+        statusBox.classList.add('bg-danger');
+    } else {
+        statusBox.classList.add('bg-warning');
+    }
 }
 
 function getBuildInfo() {
-  const infoData = buildData[0];
-  const buildDate = new Date(infoData.startTimestamp * 1000);
-  let info = infoData.title.replace('Build ', '');
-  info += ' Build ' + infoData.identifier + ', generated on ';
-  info += buildDate.toLocaleString();
-  return info;
+    const infoData = buildData[0];
+    const buildDate = new Date(infoData.startTimestamp * 1000);
+    let info = infoData.title.replace('Build ', '');
+    info += ' Build ' + infoData.identifier + ', generated on ';
+    info += buildDate.toLocaleString();
+    return info;
 }
 
 function loadMainData() {
-  mainStep = buildData[0];
-  targets = buildData.filter(function (step) {
-    return step.type === 'target' && step.fetchedFromCache === false;
-  });
-  cFiles = buildData.filter(function (step) {
-    return step.type === 'detail' && step.detailStepType === cCompilation
-    && step.fetchedFromCache === false;
-  });
-  swiftFiles = buildData.filter(function (step) {
-    return step.type === 'detail' && step.detailStepType === swiftCompilation
-    && step.fetchedFromCache === false;
-  });
+    mainStep = buildData[0];
+    targets = buildData.filter(function (step) {
+        return step.type === 'target' && step.fetchedFromCache === false;
+    });
+    cFiles = buildData.filter(function (step) {
+        return step.type === 'detail' && step.detailStepType === cCompilation
+            && step.fetchedFromCache === false;
+    });
+    swiftFiles = buildData.filter(function (step) {
+        return step.type === 'detail' && step.detailStepType === swiftCompilation
+            && step.fetchedFromCache === false;
+    });
 }
 
 function loadTargetData(target) {
-  mainStep = buildData.find(function (element) {
-    return element.type === 'target' && element.identifier === target
-    && element.fetchedFromCache === false;
-  });
-  targets = buildData.filter(function (element) {
-    return element.parentIdentifier === target && element.fetchedFromCache === false;
-  });
+    mainStep = buildData[0];
 
-  // In xcodebuild, the swift files compilation are under an Aggregated build step.
-  // This code adds them and removes the aggregated steps
-  swiftAggregatedBuilds = targets.filter(function (step) {
-    return step.detailStepType === swiftAggregatedCompilation;
-  });
-  const aggregatedSubSteps = swiftAggregatedBuilds.flatMap(function (aggregate) {
-    return buildData.filter(function (element) {
-      return element.parentIdentifier === aggregate.identifier;
+    targets = buildData.filter(function (element) {
+        return element.parentIdentifier === target && element.fetchedFromCache === false;
     });
-  });
-  targets = targets.concat(aggregatedSubSteps).filter(function (step) {
-    return step.detailStepType != swiftAggregatedCompilation;
-  }).sort(function (lhs, rhs) {
-    return lhs.startTimestamp - rhs.startTimestamp;
-  });
 
-  cFiles = targets.filter(function (step) {
-    return step.detailStepType === cCompilation;
-  });
-  swiftFiles = targets.filter(function (step) {
-    return step.detailStepType === swiftCompilation;
-  });
+    // In xcodebuild, the swift files compilation are under an Aggregated build step.
+    // This code adds them and removes the aggregated steps
+    swiftAggregatedBuilds = targets.filter(function (step) {
+        return step.detailStepType === swiftAggregatedCompilation;
+    });
+    const aggregatedSubSteps = swiftAggregatedBuilds.flatMap(function (aggregate) {
+        return buildData.filter(function (element) {
+            return element.parentIdentifier === aggregate.identifier;
+        });
+    });
+    targets = targets.concat(aggregatedSubSteps).filter(function (step) {
+        return step.detailStepType != swiftAggregatedCompilation;
+    }).sort(function (lhs, rhs) {
+        return lhs.startTimestamp - rhs.startTimestamp;
+    });
+
+    cFiles = targets.filter(function (step) {
+        return step.detailStepType === cCompilation;
+    });
+    swiftFiles = targets.filter(function (step) {
+        return step.detailStepType === swiftCompilation;
+    });
 }
 
-function drawTimeline() {
-  const dataSeries = targets.map(function (target) {
-    const title = getShortFilename(target.title, target.architecture);
-    const targetStartTimestamp = target.startTimestamp;
-    const targetEndTimestamp = target.endTimestamp;
-    const start = targetStartTimestamp;
-    const end = targetEndTimestamp === targetStartTimestamp ? targetEndTimestamp + 1 : targetEndTimestamp;
+function drawTimeline(currentTarget) {
+    const dataSeries = targets.map(function (target) {
+        const title = getShortFilename(target.title, target.architecture);
+        const targetStartTimestamp = target.startTimestamp;
+        const targetEndTimestamp = target.endTimestamp;
+        const start = targetStartTimestamp;
+        const end = targetEndTimestamp === targetStartTimestamp ? targetEndTimestamp + 1 : targetEndTimestamp;
 
-    return {
-      x: title,
-      y: [new Date(start * 1000).getTime(),
-      new Date(end * 1000).getTime()],
-      start: targetStartTimestamp,
-      end: targetEndTimestamp
-    };
-  });
+        return {
+            x: title,
+            y: [new Date(start * 1000).getTime(),
+            new Date(end * 1000).getTime()],
+            start: targetStartTimestamp,
+            end: targetEndTimestamp
+        };
+    });
 
-  const compilationSeries = targets.map(function (target) {
-    const title = getShortFilename(target.title, target.architecture);
-    const targetStartTimestamp = target.startTimestamp;
-    const targetEndTimestamp = target.compilationEndTimestamp;
-    const start = targetStartTimestamp;
-    const end = targetEndTimestamp === targetStartTimestamp ? targetEndTimestamp + 1 : targetEndTimestamp;
+    const compilationSeries = targets.map(function (target) {
+        const title = getShortFilename(target.title, target.architecture);
+        const targetStartTimestamp = target.startTimestamp;
+        const targetEndTimestamp = target.compilationEndTimestamp;
+        const start = targetStartTimestamp;
+        const end = targetEndTimestamp === targetStartTimestamp ? targetEndTimestamp + 1 : targetEndTimestamp;
 
-    return {
-      x: title,
-      y: [new Date(start * 1000).getTime(),
-      new Date(end * 1000).getTime()],
-      start: targetStartTimestamp,
-      end: targetEndTimestamp
-    };
-  });
+        return {
+            x: title,
+            y: [new Date(start * 1000).getTime(),
+            new Date(end * 1000).getTime()],
+            start: targetStartTimestamp,
+            end: targetEndTimestamp
+        };
+    });
 
 
-  var options = {
-    series: [
-    {
-      name: 'Build time',
-      data: dataSeries
-    },
-    {
-      name: 'Compilation time',
-      data: compilationSeries
-    }
-  ],
-    chart: {
-      height: dataSeries.length * rowHeight,
-      type: 'rangeBar',
-      events: {
-        dataPointSelection: function (event, chartContext, config) {
-          const selectedItem = targets[config.dataPointIndex];
-          itemSelected(selectedItem);
+    var options = {
+        series: [
+            {
+                name: 'Build time',
+                data: dataSeries
+            },
+            {
+                name: 'Compilation time',
+                data: compilationSeries
+            }
+        ],
+        chart: {
+            height: dataSeries.length * rowHeight,
+            type: 'rangeBar',
+            events: {
+                dataPointSelection: function (event, chartContext, config) {
+                    const selectedItem = targets[config.dataPointIndex];
+                    itemSelected(currentTarget, selectedItem);
+                }
+            }
+        },
+        plotOptions: {
+            bar: {
+                horizontal: true,
+                barHeight: '80%'
+            }
+        },
+        xaxis: {
+            type: 'datetime'
+        },
+        stroke: {
+            width: 1
+        },
+        fill: {
+            type: 'solid',
+            opacity: 0.6
+        },
+        legend: {
+            position: 'top',
+            horizontalAlign: 'left'
+        },
+        tooltip: {
+            enabled: true,
+            custom: function ({series, seriesIndex, dataPointIndex, w}) {
+                const serie = dataSeries[dataPointIndex];
+                const start = serie.start;
+                const end = serie.end;
+                const duration = (end - start).toFixed(3);
+                return '<div class="arrow_box">' +
+                    '<span>' + serie.x + ' </span><br>' +
+                    '<span>' + duration + ' seconds</span>' +
+                    '</div>'
+            },
+            y: {
+                enabled: true,
+                show: true,
+                formatter: undefined,
+                title: {
+                    formatter: (seriesName) => seriesName,
+                },
+            },
+
         }
-      }
-  },
-  plotOptions: {
-    bar: {
-      horizontal: true,
-      barHeight: '80%'
-    }
-  },
-  xaxis: {
-    type: 'datetime'
-  },
-  stroke: {
-    width: 1
-  },
-  fill: {
-    type: 'solid',
-    opacity: 0.6
-  },
-  legend: {
-    position: 'top',
-    horizontalAlign: 'left'
-  },
-  tooltip: {
-    enabled: true,
-    custom: function ({ series, seriesIndex, dataPointIndex, w }) {
-      const serie = dataSeries[dataPointIndex];
-      const start = serie.start;
-      const end = serie.end;
-      const duration = (end - start).toFixed(3);
-      return '<div class="arrow_box">' +
-        '<span>' + serie.x + ' </span><br>' +
-        '<span>' + duration + ' seconds</span>' +
-        '</div>'
-    },
-    y: {
-      enabled: true,
-      show: true,
-      formatter: undefined,
-      title: {
-        formatter: (seriesName) => seriesName,
-      },
-    },
+    };
 
-  }
-  };
-
-  var chart = new ApexCharts(document.querySelector("#timeline"), options);
-  chart.render();
+    var chart = new ApexCharts(document.querySelector("#timeline"), options);
+    chart.render();
 }
 
 function drawSlowestTargets(target) {
-  let clone = targets.slice(0);
-  const targetsData = clone.sort(function (lhs, rhs) {
-    return rhs.duration - lhs.duration
-  });
-  const top = Math.min(20, targetsData.length);
-  const topTargets = targetsData.slice(0, top);
-  const durations = topTargets.map(function (target) {
-    return target.duration.toFixed(3);
-  });
-  const names = topTargets.map(function (step) {
-    if (target === 'main') {
-      return step.title.replace('Build target ', '');
-    } else {
-      return getShortFilename(step.title, step.architecture);
-    }
-  });
-  const options = {
-    chart: {
-      height: names.length * rowHeight,
-      type: 'bar',
-      events: {
-        dataPointSelection: function (event, chartContext, config) {
-          const selectedItem = topTargets[config.dataPointIndex];
-          itemSelected(selectedItem);
+    let clone = targets.slice(0);
+    const targetsData = clone.sort(function (lhs, rhs) {
+        return rhs.duration - lhs.duration
+    });
+    const top = Math.min(20, targetsData.length);
+    const topTargets = targetsData.slice(0, top);
+    const durations = topTargets.map(function (target) {
+        return target.duration.toFixed(3);
+    });
+    const names = topTargets.map(function (step) {
+        if (target === 'main') {
+            return step.title.replace('Build target ', '');
+        } else {
+            return getShortFilename(step.title, step.architecture);
         }
-      }
-    },
-    plotOptions: {
-      bar: {
-        distributed: true,
-        horizontal: true
-      }
-    },
-    dataLabels: {
-      enabled: false
-    },
-    series: [{
-      data: durations
-    }],
-    xaxis: {
-      categories: names
-    },
-    legend: {
-      show: false
-    },
-    tooltip: {
-      y: {
-        title: {
-          formatter: function () {
-            return 'Seconds'
-          }
+    });
+    const options = {
+        chart: {
+            height: names.length * rowHeight,
+            type: 'bar',
+            events: {
+                dataPointSelection: function (event, chartContext, config) {
+                    const selectedItem = topTargets[config.dataPointIndex];
+                    itemSelected(target, selectedItem);
+                }
+            }
+        },
+        plotOptions: {
+            bar: {
+                distributed: true,
+                horizontal: true
+            }
+        },
+        dataLabels: {
+            enabled: false
+        },
+        series: [{
+            data: durations
+        }],
+        xaxis: {
+            categories: names
+        },
+        legend: {
+            show: false
+        },
+        tooltip: {
+            y: {
+                title: {
+                    formatter: function () {
+                        return 'Seconds'
+                    }
+                }
+            }
         }
-      }
     }
-  }
 
-  var chart = new ApexCharts(
-    document.querySelector("#bartargets"),
-    options
-  );
+    var chart = new ApexCharts(
+        document.querySelector("#bartargets"),
+        options
+    );
 
-  chart.render();
+    chart.render();
 }
 
 
-function drawSlowestFiles(collection, element) {
-  const sortedData = collection.sort(function (lhs, rhs) {
-    return rhs.duration - lhs.duration;
-  });
-  const top = Math.min(20, sortedData.length);
-  const topTargets = sortedData.slice(0, top);
-  const durations = topTargets.map(function (target) {
-    return target.duration.toFixed(3);
-  });
-  const names = topTargets.map(function (step) {
-    return getShortFilename(step.title, step.architecture);
-  });
-  const options = {
-    chart: {
-      height: names.length * rowHeight,
-      type: 'bar',
-      events: {
-        dataPointSelection: function (event, chartContext, config) {
-          const selectedItem = topTargets[config.dataPointIndex];
-          itemSelected(selectedItem);
+function drawSlowestFiles(collection, element, currentTarget) {
+    const sortedData = collection.sort(function (lhs, rhs) {
+        return rhs.duration - lhs.duration;
+    });
+    const top = Math.min(20, sortedData.length);
+    const topTargets = sortedData.slice(0, top);
+    const durations = topTargets.map(function (target) {
+        return target.duration.toFixed(3);
+    });
+    const names = topTargets.map(function (step) {
+        return getShortFilename(step.title, step.architecture);
+    });
+    const options = {
+        chart: {
+            height: names.length * rowHeight,
+            type: 'bar',
+            events: {
+                dataPointSelection: function (event, chartContext, config) {
+                    const selectedItem = topTargets[config.dataPointIndex];
+                    itemSelected(currentTarget, selectedItem);
+                }
+            }
+        },
+        plotOptions: {
+            bar: {
+                distributed: true,
+                horizontal: true
+            }
+        },
+        dataLabels: {
+            enabled: false
+        },
+        series: [{
+            data: durations
+        }],
+        xaxis: {
+            categories: names
+        },
+        legend: {
+            show: false
+        },
+        tooltip: {
+            y: {
+                title: {
+                    formatter: function () {
+                        return 'Seconds'
+                    }
+                }
+            }
         }
-      }
-    },
-    plotOptions: {
-      bar: {
-        distributed: true,
-        horizontal: true
-      }
-    },
-    dataLabels: {
-      enabled: false
-    },
-    series: [{
-      data: durations
-    }],
-    xaxis: {
-      categories: names
-    },
-    legend: {
-      show: false
-    },
-    tooltip: {
-      y: {
-        title: {
-          formatter: function () {
-            return 'Seconds'
-          }
-        }
-      }
     }
-  }
 
-  var chart = new ApexCharts(
-    document.querySelector(element),
-    options
-  );
+    var chart = new ApexCharts(
+        document.querySelector(element),
+        options
+    );
 
-  chart.render();
+    chart.render();
 }
 
 function getRequestedTarget() {
-  let name = "target"
-  if (name = (new RegExp('[?&]' + encodeURIComponent(name) + '=([^&]*)')).exec(location.search)) {
-    return decodeURIComponent(name[1]);
-  } else {
-    return "main"
-  }
+    return "{{target_name}}";
 }
 
 function getShortFilename(fileName, arch) {
-  if (fileName.includes('/')) {
-    const components = fileName.replace('Compile ', '').split('/');
-    const command = fileName.split(' ')[0]
-    const startIndex = Math.max(3, components.length - 3);
-    if (arch != '') {
-      return command + ' ' + arch + ' ' + components.slice(startIndex, components.length).join('/');
+    if (fileName.includes('/')) {
+        const components = fileName.replace('Compile ', '').split('/');
+        const command = fileName.split(' ')[0]
+        const startIndex = Math.max(3, components.length - 3);
+        if (arch != '') {
+            return command + ' ' + arch + ' ' + components.slice(startIndex, components.length).join('/');
+        }
+        return command + ' ' + components.slice(startIndex, components.length).join('/');
+    } else {
+        return fileName
     }
-    return command + ' ' + components.slice(startIndex, components.length).join('/');
-  } else {
-    return fileName
-  }
 }
 
 function drawErrors(target) {
-  $('#errors-count').html(mainStep.errorCount);
-  showErrors(target);
+    $('#errors-count').html(mainStep.errorCount);
+    showErrors(target);
 }
 
 function drawWarnings(target) {
-  $('#warnings-count').html(mainStep.warningCount);
-  showWarnings(target);
+    $('#warnings-count').html(mainStep.warningCount);
+    showWarnings(target);
 }
 
 function showErrors(target) {
-  const steps = target === 'main' ? buildData : targets;
-  const stepsWithErrors = steps.filter(function (step) {
-    return step.type != 'main' && step.type != 'target' && step.errorCount > 0;
-  }).sort(function (lhs, rhs) {
-    return rhs.warningCount - lhs.warningCount;
-  });
-  var summaries = '';
-  stepsWithErrors.forEach(function (step) {
-    const errorLegend = step.errorCount > 1 ? " errors in " : " error in ";
-    summaries += incidentTemplate({ "count": step.errorCount + errorLegend, "summary": step.signature, "details": step.errors });
-  });
-  $('#errors-summary').html(summaries);
-  if (stepsWithErrors.length > 0) {
-    $('#errors').show();
-  } else {
-    $('#errors').hide();
-  }
+    var stepsErrors;
+    if (target === 'main') {
+        stepsErrors = stepsWithErrors;
+    } else {
+        stepsErrors = targets.filter(function (step) {
+            return step.type != 'main' && step.type != 'target' && step.errorCount > 0;
+        }).sort(function (lhs, rhs) {
+            return rhs.errorCount - lhs.errorCount;
+        });
+    }
+    var summaries = '';
+    stepsErrors.forEach(function (step) {
+        const errorLegend = step.errorCount > 1 ? " errors in " : " error in ";
+        summaries += incidentTemplate({"count": step.errorCount + errorLegend, "summary": step.signature, "details": step.errors});
+    });
+    $('#errors-summary').html(summaries);
+    if (stepsErrors.length > 0) {
+        $('#errors').show();
+    } else {
+        $('#errors').hide();
+    }
 }
 
 function showWarnings(target) {
-  const steps = target === 'main' ? buildData : targets;
-  const stepsWithWarnings = steps.filter(function (step) {
-    return step.warnings.length > 0;
-  }).sort(function (lhs, rhs) {
-    return rhs.warningCount - lhs.warningCount;
-  });
-  var summaries = '';
-  stepsWithWarnings.forEach(function (step) {
-    if (step.warnings.length > 0) {
-      const warningLegend = step.warningCount > 1 ? " warnings in " : " warning in ";
-      summaries += incidentTemplate({ "count": step.warningCount + warningLegend, "summary": step.signature, "details": step.warnings });
+    var stepsWarnings;
+    if (target === 'main') {
+        stepsWarnings = stepsWithWarnings;
+    } else {
+        stepsWarnings = buildData.filter(function (step) {
+            return step.type != 'target' && step.warningCount > 0;
+        }).sort(function (lhs, rhs) {
+            return rhs.errorCount - lhs.errorCount;
+        });
     }
-  });
-  $('#warnings-summary').html(summaries);
-  if (stepsWithWarnings.length > 0) {
-    $('#warnings').show();
-  } else {
-    $('#warnings').hide();
-  }
+    var summaries = '';
+    stepsWarnings.forEach(function (step) {
+        if (step.warnings.length > 0) {
+            const warningLegend = step.warningCount > 1 ? " warnings in " : " warning in ";
+            summaries += incidentTemplate({"count": step.warningCount + warningLegend, "summary": step.signature, "details": step.warnings});
+        }
+    });
+    $('#warnings-summary').html(summaries);
+    if (stepsWarnings.length > 0) {
+        $('#warnings').show();
+    } else {
+        $('#warnings').hide();
+    }
 }
 
-function itemSelected(selectedItem) {
-  if (selectedItem.type === 'target') {
-    window.location.href = window.location.href + "?target=" + selectedItem.identifier;
-  } else if (selectedItem.type === 'detail') {
-    const stepUrl = window.location.href.replace('index.html', 'step.html');
-    window.location.href =  stepUrl + "?step=" + selectedItem.identifier;
-  }
+function itemSelected(target, selectedItem) {
+    if (selectedItem.type === 'target') {
+        const fileName = selectedItem.identifier.replaceAll(' ', '_');
+        window.location.href = window.location.href.replace('index.html', fileName + '.html');
+    } else if (selectedItem.type === 'detail') {
+        const targetId = selectedItem.parentIdentifier.replaceAll(' ', '_');
+        if (target === 'main') {
+            const stepUrl = window.location.href.replace(encodeURI('{{file_name}}'), targetId + '.html');
+            window.location.href = stepUrl + "?step=" + selectedItem.identifier;
+        } else {
+            const stepUrl = window.location.href.replace(encodeURI('{{file_name}}'), '{{steps_name}}');
+            window.location.href = stepUrl + "?step=" + selectedItem.identifier;
+        }
+    }
 }
 
 function drawSwiftFunctions(target) {
-  const steps = target === 'main' ? buildData : targets;
-  const swiftFunctions = steps.filter(function (step) {
-    return step.swiftFunctionTimes && step.swiftFunctionTimes.length > 0;
-  }).flatMap(function (step) {
-    return step.swiftFunctionTimes
-  }).map(function(f) {
-    f.cumulative = Math.round(f.occurrences * f.durationMS * 100) / 100;
-    return f;
-  }).sort(function (lhs, rhs) {
-    return rhs.durationMS - lhs.durationMS;
-  });
-  if (swiftFunctions.length > 0) {
-    const functions = swiftFunctionTemplate({"functions": swiftFunctions});
-    $('#swiftfunctions').html(functions);
-    $('#swift-functions-table').DataTable({
-      "info": false,
-      "scrollX": true,
-      "order": [[ 0, "desc" ]]
+    let swiftFunctions;
+    if (target === 'main') {
+        swiftFunctions = topSwiftFunctions;
+    } else {
+        swiftFunctions = targets.filter(function (step) {
+            return step.swiftFunctionTimes && step.swiftFunctionTimes.length > 0;
+        }).flatMap(function (step) {
+            return step.swiftFunctionTimes
+        });
+    }
+
+    const cumulativeSwiftFunctions = swiftFunctions.map(function (f) {
+        f.cumulative = Math.round(f.occurrences * f.durationMS * 100) / 100;
+        return f;
     });
-  } else {
-    $('#swiftfunctions').html(swiftFunctionWarning);
-  }
+    if (cumulativeSwiftFunctions.length > 0) {
+        const functions = swiftFunctionTemplate({"functions": cumulativeSwiftFunctions});
+        $('#swiftfunctions').html(functions);
+        $('#swift-functions-table').DataTable({
+            "info": false,
+            "scrollX": true,
+            "order": [[0, "desc"]]
+        });
+    } else {
+        $('#swiftfunctions').html(swiftFunctionWarning);
+    }
 }
 
 function drawSwiftTypeChecks(target) {
-  const steps = target === 'main' ? buildData : targets;
-  const swiftTypeCheckTimes = steps.filter(function (step) {
-    return step.swiftTypeCheckTimes && step.swiftTypeCheckTimes.length > 0;
-  }).flatMap(function (step) {
-    return step.swiftTypeCheckTimes
-  }).map(function(f) {
-    f.cumulative = Math.round(f.occurrences * f.durationMS * 100) / 100;
-    return f;
-  }).sort(function (lhs, rhs) {
-    return rhs.durationMS - lhs.durationMS;
-  });
-  if (swiftTypeCheckTimes.length > 0) {
-    const functions = swiftTypeCheckTemplate({"functions": swiftTypeCheckTimes});
-    $('#swifttypechecks').html(functions);
-    $('#swift-typechecks-table').DataTable({
-      "info": false,
-      "scrollX": true,
-      "order": [[ 0, "desc" ]]
+    let swiftTypeCheckTimes;
+    if (target === 'main') {
+        swiftTypeCheckTimes = topSwifTypeChecks;
+    } else {
+        swiftTypeCheckTimes = targets.filter(function (step) {
+            return step.swiftTypeCheckTimes && step.swiftTypeCheckTimes.length > 0;
+        }).flatMap(function (step) {
+            return step.swiftTypeCheckTimes
+        });
+    }
+
+    const cumulativeSwiftTypeCheckTimes = swiftTypeCheckTimes.map(function (f) {
+        f.cumulative = Math.round(f.occurrences * f.durationMS * 100) / 100;
+        return f;
     });
-  } else {
-    $('#swifttypechecks').html(swiftTypeCheckWarning);
-  }
+    if (swiftTypeCheckTimes.length > 0) {
+        const functions = swiftTypeCheckTemplate({"functions": cumulativeSwiftTypeCheckTimes});
+        $('#swifttypechecks').html(functions);
+        $('#swift-typechecks-table').DataTable({
+            "info": false,
+            "scrollX": true,
+            "order": [[0, "desc"]]
+        });
+    } else {
+        $('#swifttypechecks').html(swiftTypeCheckWarning);
+    }
 }

--- a/Resources/step.html
+++ b/Resources/step.html
@@ -246,7 +246,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.1.2/handlebars.min.js"></script>
-  <script type="text/javascript" src="js/build.js"></script>
+      <script type="text/javascript" src="js/{{data_file}}"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.23.0/moment-with-locales.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script type="text/javascript" src="js/step.js"></script>

--- a/Resources/step.html
+++ b/Resources/step.html
@@ -246,7 +246,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.1.2/handlebars.min.js"></script>
-      <script type="text/javascript" src="js/{{data_file}}"></script>
+  <script type="text/javascript" src="js/{{data_file}}"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.23.0/moment-with-locales.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script type="text/javascript" src="js/step.js"></script>

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.19"
+    public static let current = "0.2.20"
 
 }

--- a/Sources/XCLogParser/generated/HtmlReporterResources.swift
+++ b/Sources/XCLogParser/generated/HtmlReporterResources.swift
@@ -123,82 +123,82 @@ const swiftCompilation = 'swiftCompilation';
 const cCompilation = 'cCompilation'
 
 const incidentSource = "<details>" +
-  "<summary><span class='font-weight-bold'>{{count}}</span>{{summary}}</summary>" +
-  "<p class='bg-light'>" +
-  "<ul>" +
-  "{{#each details}}" +
-  "{{#if documentURL}}" +
-  "<li>{{clangWarning}} {{title}} " +
-  "In <a href='{{documentURL}}'>{{documentURL}}</a> Line {{startingLineNumber}} column {{startingColumnNumber}}</li>" +
-  "{{else}}" +
-  "<li>{{clangWarning}} {{title}}</li>" +
-  "{{/if}}" +
-  "{{/each}}" +
-  "</ul>" +
-  "</p>" +
-  "</details>";
+    "<summary><span class='font-weight-bold'>{{count}}</span>{{summary}}</summary>" +
+    "<p class='bg-light'>" +
+    "<ul>" +
+    "{{#each details}}" +
+    "{{#if documentURL}}" +
+    "<li>{{clangWarning}} {{title}} " +
+    "In <a href='{{documentURL}}'>{{documentURL}}</a> Line {{startingLineNumber}} column {{startingColumnNumber}}</li>" +
+    "{{else}}" +
+    "<li>{{clangWarning}} {{title}}</li>" +
+    "{{/if}}" +
+    "{{/each}}" +
+    "</ul>" +
+    "</p>" +
+    "</details>";
 
 const incidentTemplate = Handlebars.compile(incidentSource);
 
 const swiftFunctionSource = "<table id='swift-functions-table' class='display table table-sm table-hover table-responsive table-striped'>" +
-  "<thead>" +
-  "<tr>" +
-  "<th scope='col'>Duration (ms)</th>" +
-  "<th scope='col'>File</th>" +
-  "<th scope='col'>Function</th>" +
-  "<th scope='col'>Line</th>" +
-  "<th scope='col'>Column</th>" +
-  "<th scope='col'>Occurrences</th>" +
-  "<th scope='col'>Cumulative (ms)</th>" +
-  "</tr>" +
-  "</thead>" +
-  "{{#each functions}}" +
-  "<tr>" +
-  "<th scope='col'>{{durationMS}}</th>" +
-  "<th scope='col'>{{file}}</th>" +
-  "<th scope='col'>{{signature}}</th>" +
-  "<th scope='col'>{{startingLine}}</th>" +
-  "<th scope='col'>{{startingColumn}}</th>" +
-  "<th scope='col'>{{occurrences}}</th>" +
-  "<th scope='col'>{{cumulative}}</th>" +
-  "</tr>" +
-  "{{/each}}" +
-  "</table>";
+    "<thead>" +
+    "<tr>" +
+    "<th scope='col'>Duration (ms)</th>" +
+    "<th scope='col'>File</th>" +
+    "<th scope='col'>Function</th>" +
+    "<th scope='col'>Line</th>" +
+    "<th scope='col'>Column</th>" +
+    "<th scope='col'>Occurrences</th>" +
+    "<th scope='col'>Cumulative (ms)</th>" +
+    "</tr>" +
+    "</thead>" +
+    "{{#each functions}}" +
+    "<tr>" +
+    "<th scope='col'>{{durationMS}}</th>" +
+    "<th scope='col'>{{file}}</th>" +
+    "<th scope='col'>{{signature}}</th>" +
+    "<th scope='col'>{{startingLine}}</th>" +
+    "<th scope='col'>{{startingColumn}}</th>" +
+    "<th scope='col'>{{occurrences}}</th>" +
+    "<th scope='col'>{{cumulative}}</th>" +
+    "</tr>" +
+    "{{/each}}" +
+    "</table>";
 
 const swiftTypeCheckSource = "<table id='swift-typechecks-table' class='table table-sm table-hover table-responsive table-striped'>" +
-  "<thead>" +
-  "<tr>" +
-  "<th scope='col'>Duration (ms)</th>" +
-  "<th scope='col'>File</th>" +
-  "<th scope='col'>Line</th>" +
-  "<th scope='col'>Column</th>" +
-  "<th scope='col'>Occurrences</th>" +
-  "<th scope='col'>Cumulative (ms)</th>" +
-  "</tr>" +
-  "</thead>" +
-  "{{#each functions}}" +
-  "<tr>" +
-  "<th scope='col'>{{durationMS}}</th>" +
-  "<th scope='col'>{{file}}</th>" +
-  "<th scope='col'>{{startingLine}}</th>" +
-  "<th scope='col'>{{startingColumn}}</th>" +
-  "<th scope='col'>{{occurrences}}</th>" +
-  "<th scope='col'>{{cumulative}}</th>" +
-  "</tr>" +
-  "{{/each}}" +
-  "</table>";
+    "<thead>" +
+    "<tr>" +
+    "<th scope='col'>Duration (ms)</th>" +
+    "<th scope='col'>File</th>" +
+    "<th scope='col'>Line</th>" +
+    "<th scope='col'>Column</th>" +
+    "<th scope='col'>Occurrences</th>" +
+    "<th scope='col'>Cumulative (ms)</th>" +
+    "</tr>" +
+    "</thead>" +
+    "{{#each functions}}" +
+    "<tr>" +
+    "<th scope='col'>{{durationMS}}</th>" +
+    "<th scope='col'>{{file}}</th>" +
+    "<th scope='col'>{{startingLine}}</th>" +
+    "<th scope='col'>{{startingColumn}}</th>" +
+    "<th scope='col'>{{occurrences}}</th>" +
+    "<th scope='col'>{{cumulative}}</th>" +
+    "</tr>" +
+    "{{/each}}" +
+    "</table>";
 
 const swiftFunctionWarning = "<div class='callout callout-warning'>" +
-"<small class='text-muted'>Warning: No Swift function compilation times were found.</small>" +
-"<br>" +
-"Did you compile your project with the flags -Xfrontend -debug-time-function-bodies?" +
-"</div>";
+    "<small class='text-muted'>Warning: No Swift function compilation times were found.</small>" +
+    "<br>" +
+    "Did you compile your project with the flags -Xfrontend -debug-time-function-bodies?" +
+    "</div>";
 
 const swiftTypeCheckWarning = "<div class='callout callout-warning'>" +
-"<small class='text-muted'>Warning: No Swiftc type checks times were found.</small>" +
-"<br>" +
-"Did you compile your project with the flags -Xfrontend -debug-time-expression-type-checking?" +
-"</div>";
+    "<small class='text-muted'>Warning: No Swiftc type checks times were found.</small>" +
+    "<br>" +
+    "Did you compile your project with the flags -Xfrontend -debug-time-expression-type-checking?" +
+    "</div>";
 
 const swiftFunctionTemplate = Handlebars.compile(swiftFunctionSource);
 
@@ -207,495 +207,506 @@ const swiftTypeCheckTemplate = Handlebars.compile(swiftTypeCheckSource);
 drawCharts();
 
 function drawCharts() {
-  const target = getRequestedTarget();
-  if (target === 'main') {
-    loadMainData();
-  } else {
-    loadTargetData(target);
-  }
-  drawHeaders(target);
-  drawErrors(target);
-  drawWarnings(target);
-  drawTimeline();
-  drawSlowestTargets(target);
+    const target = getRequestedTarget();
+    if (target === 'main') {
+        loadMainData();
+    } else {
+        loadTargetData(target);
+    }
+    drawHeaders(target);
+    drawErrors(target);
+    drawWarnings(target);
+    drawTimeline(target);
+    drawSlowestTargets(target);
 
-  if (target === 'main') {
-    document.getElementById('files-row').style.display = 'flex';
-    drawSlowestFiles(cFiles, '#top_cfiles');
-    drawSlowestFiles(swiftFiles, '#top_swiftfiles');
-  } else {
-    document.getElementById('files-row').style.display = 'none';
-  }
-  drawSwiftFunctions(target);
-  drawSwiftTypeChecks(target);
+    if (target === 'main') {
+        document.getElementById('files-row').style.display = 'flex';
+        drawSlowestFiles(cSlowestFiles, '#top_cfiles', target);
+        drawSlowestFiles(swiftSlowestFiles, '#top_swiftfiles', target);
+    } else {
+        document.getElementById('files-row').style.display = 'none';
+    }
+    drawSwiftFunctions(target);
+    drawSwiftTypeChecks(target);
 }
 
 function drawHeaders(target) {
-  setBuildStatus();
-  document.getElementById('build-info').innerHTML = getBuildInfo();
-  if (target === 'main') {
-    document.getElementById('schema-title').innerHTML = 'Schema';
-    document.getElementById('schema').innerHTML = mainStep.schema;
-    document.getElementById('targets-title').innerHTML = 'Targets';
-  } else {
-    document.getElementById('schema-title').innerHTML = 'Target';
-    document.getElementById('schema').innerHTML = mainStep.title.replace('Build target', '');
-    document.getElementById('targets-title').innerHTML = 'Files';
-  }
-  const status = mainStep.buildStatus.charAt(0).toUpperCase() + mainStep.buildStatus.slice(1);
-  document.getElementById('build-status').innerHTML = status;
-  const duration = moment.duration(mainStep.duration * 1000);
-  var durationText = '';
-  if (duration.hours() > 0) {
-    durationText += duration.hours() + ' hrs, ';
-  }
-  if (duration.minutes() > 0) {
-    durationText += duration.minutes() + ' mins, ';
-  }
-  durationText += Math.round(duration.seconds()) + ' secs';
-  document.getElementById('build-time').innerHTML = durationText;
-  document.getElementById('targets').innerHTML = targets.length.toLocaleString('en');
-  const cCompiledFiles = cFiles.filter(function (file) {
-    return file.fetchedFromCache == false;
-  })
-  const swiftCompiledFiles = swiftFiles.filter(function (file) {
-    return file.fetchedFromCache == false;
-  })
-  document.getElementById('c-files-total').innerHTML = cFiles.length.toLocaleString('en') + ' total';
-  document.getElementById('swift-files-total').innerHTML = swiftFiles.length.toLocaleString('en') + ' total';
+    setBuildStatus();
+    document.getElementById('build-info').innerHTML = getBuildInfo();
+    if (target === 'main') {
+        document.getElementById('schema-title').innerHTML = 'Schema';
+        document.getElementById('schema').innerHTML = mainStep.schema;
+        document.getElementById('targets-title').innerHTML = 'Targets';
+    } else {
+        document.getElementById('schema-title').innerHTML = 'Target';
+        document.getElementById('schema').innerHTML = mainStep.title.replace('Build target', '');
+        document.getElementById('targets-title').innerHTML = 'Files';
+    }
+    const status = mainStep.buildStatus.charAt(0).toUpperCase() + mainStep.buildStatus.slice(1);
+    document.getElementById('build-status').innerHTML = status;
+    const duration = moment.duration(mainStep.duration * 1000);
+    var durationText = '';
+    if (duration.hours() > 0) {
+        durationText += duration.hours() + ' hrs, ';
+    }
+    if (duration.minutes() > 0) {
+        durationText += duration.minutes() + ' mins, ';
+    }
+    durationText += Math.round(duration.seconds()) + ' secs';
+    document.getElementById('build-time').innerHTML = durationText;
+    document.getElementById('targets').innerHTML = targets.length.toLocaleString('en');
+
+    document.getElementById('c-files-total').innerHTML = cFiles.length.toLocaleString('en') + ' total';
+    document.getElementById('swift-files-total').innerHTML = swiftFiles.length.toLocaleString('en') + ' total';
 
 }
 
 function setBuildStatus() {
-  const status = mainStep.buildStatus.charAt(0).toUpperCase() + mainStep.buildStatus.slice(1);
-  const statusBox = document.getElementById('status-box');
-  if (status.toLowerCase() === 'succeeded') {
-    statusBox.classList.add('bg-success');
-  } else if (status.toLowerCase().includes('failed') || status.toLowerCase().includes('errors')) {
-    statusBox.classList.add('bg-danger');
-  } else {
-    statusBox.classList.add('bg-warning');
-  }
+    const status = mainStep.buildStatus.charAt(0).toUpperCase() + mainStep.buildStatus.slice(1);
+    const statusBox = document.getElementById('status-box');
+    if (status.toLowerCase() === 'succeeded') {
+        statusBox.classList.add('bg-success');
+    } else if (status.toLowerCase().includes('failed') || status.toLowerCase().includes('errors')) {
+        statusBox.classList.add('bg-danger');
+    } else {
+        statusBox.classList.add('bg-warning');
+    }
 }
 
 function getBuildInfo() {
-  const infoData = buildData[0];
-  const buildDate = new Date(infoData.startTimestamp * 1000);
-  let info = infoData.title.replace('Build ', '');
-  info += ' Build ' + infoData.identifier + ', generated on ';
-  info += buildDate.toLocaleString();
-  return info;
+    const infoData = buildData[0];
+    const buildDate = new Date(infoData.startTimestamp * 1000);
+    let info = infoData.title.replace('Build ', '');
+    info += ' Build ' + infoData.identifier + ', generated on ';
+    info += buildDate.toLocaleString();
+    return info;
 }
 
 function loadMainData() {
-  mainStep = buildData[0];
-  targets = buildData.filter(function (step) {
-    return step.type === 'target' && step.fetchedFromCache === false;
-  });
-  cFiles = buildData.filter(function (step) {
-    return step.type === 'detail' && step.detailStepType === cCompilation
-    && step.fetchedFromCache === false;
-  });
-  swiftFiles = buildData.filter(function (step) {
-    return step.type === 'detail' && step.detailStepType === swiftCompilation
-    && step.fetchedFromCache === false;
-  });
+    mainStep = buildData[0];
+    targets = buildData.filter(function (step) {
+        return step.type === 'target' && step.fetchedFromCache === false;
+    });
+    cFiles = buildData.filter(function (step) {
+        return step.type === 'detail' && step.detailStepType === cCompilation
+            && step.fetchedFromCache === false;
+    });
+    swiftFiles = buildData.filter(function (step) {
+        return step.type === 'detail' && step.detailStepType === swiftCompilation
+            && step.fetchedFromCache === false;
+    });
 }
 
 function loadTargetData(target) {
-  mainStep = buildData.find(function (element) {
-    return element.type === 'target' && element.identifier === target
-    && element.fetchedFromCache === false;
-  });
-  targets = buildData.filter(function (element) {
-    return element.parentIdentifier === target && element.fetchedFromCache === false;
-  });
+    mainStep = buildData[0];
 
-  // In xcodebuild, the swift files compilation are under an Aggregated build step.
-  // This code adds them and removes the aggregated steps
-  swiftAggregatedBuilds = targets.filter(function (step) {
-    return step.detailStepType === swiftAggregatedCompilation;
-  });
-  const aggregatedSubSteps = swiftAggregatedBuilds.flatMap(function (aggregate) {
-    return buildData.filter(function (element) {
-      return element.parentIdentifier === aggregate.identifier;
+    targets = buildData.filter(function (element) {
+        return element.parentIdentifier === target && element.fetchedFromCache === false;
     });
-  });
-  targets = targets.concat(aggregatedSubSteps).filter(function (step) {
-    return step.detailStepType != swiftAggregatedCompilation;
-  }).sort(function (lhs, rhs) {
-    return lhs.startTimestamp - rhs.startTimestamp;
-  });
 
-  cFiles = targets.filter(function (step) {
-    return step.detailStepType === cCompilation;
-  });
-  swiftFiles = targets.filter(function (step) {
-    return step.detailStepType === swiftCompilation;
-  });
+    // In xcodebuild, the swift files compilation are under an Aggregated build step.
+    // This code adds them and removes the aggregated steps
+    swiftAggregatedBuilds = targets.filter(function (step) {
+        return step.detailStepType === swiftAggregatedCompilation;
+    });
+    const aggregatedSubSteps = swiftAggregatedBuilds.flatMap(function (aggregate) {
+        return buildData.filter(function (element) {
+            return element.parentIdentifier === aggregate.identifier;
+        });
+    });
+    targets = targets.concat(aggregatedSubSteps).filter(function (step) {
+        return step.detailStepType != swiftAggregatedCompilation;
+    }).sort(function (lhs, rhs) {
+        return lhs.startTimestamp - rhs.startTimestamp;
+    });
+
+    cFiles = targets.filter(function (step) {
+        return step.detailStepType === cCompilation;
+    });
+    swiftFiles = targets.filter(function (step) {
+        return step.detailStepType === swiftCompilation;
+    });
 }
 
-function drawTimeline() {
-  const dataSeries = targets.map(function (target) {
-    const title = getShortFilename(target.title, target.architecture);
-    const targetStartTimestamp = target.startTimestamp;
-    const targetEndTimestamp = target.endTimestamp;
-    const start = targetStartTimestamp;
-    const end = targetEndTimestamp === targetStartTimestamp ? targetEndTimestamp + 1 : targetEndTimestamp;
+function drawTimeline(currentTarget) {
+    const dataSeries = targets.map(function (target) {
+        const title = getShortFilename(target.title, target.architecture);
+        const targetStartTimestamp = target.startTimestamp;
+        const targetEndTimestamp = target.endTimestamp;
+        const start = targetStartTimestamp;
+        const end = targetEndTimestamp === targetStartTimestamp ? targetEndTimestamp + 1 : targetEndTimestamp;
 
-    return {
-      x: title,
-      y: [new Date(start * 1000).getTime(),
-      new Date(end * 1000).getTime()],
-      start: targetStartTimestamp,
-      end: targetEndTimestamp
-    };
-  });
+        return {
+            x: title,
+            y: [new Date(start * 1000).getTime(),
+            new Date(end * 1000).getTime()],
+            start: targetStartTimestamp,
+            end: targetEndTimestamp
+        };
+    });
 
-  const compilationSeries = targets.map(function (target) {
-    const title = getShortFilename(target.title, target.architecture);
-    const targetStartTimestamp = target.startTimestamp;
-    const targetEndTimestamp = target.compilationEndTimestamp;
-    const start = targetStartTimestamp;
-    const end = targetEndTimestamp === targetStartTimestamp ? targetEndTimestamp + 1 : targetEndTimestamp;
+    const compilationSeries = targets.map(function (target) {
+        const title = getShortFilename(target.title, target.architecture);
+        const targetStartTimestamp = target.startTimestamp;
+        const targetEndTimestamp = target.compilationEndTimestamp;
+        const start = targetStartTimestamp;
+        const end = targetEndTimestamp === targetStartTimestamp ? targetEndTimestamp + 1 : targetEndTimestamp;
 
-    return {
-      x: title,
-      y: [new Date(start * 1000).getTime(),
-      new Date(end * 1000).getTime()],
-      start: targetStartTimestamp,
-      end: targetEndTimestamp
-    };
-  });
+        return {
+            x: title,
+            y: [new Date(start * 1000).getTime(),
+            new Date(end * 1000).getTime()],
+            start: targetStartTimestamp,
+            end: targetEndTimestamp
+        };
+    });
 
 
-  var options = {
-    series: [
-    {
-      name: 'Build time',
-      data: dataSeries
-    },
-    {
-      name: 'Compilation time',
-      data: compilationSeries
-    }
-  ],
-    chart: {
-      height: dataSeries.length * rowHeight,
-      type: 'rangeBar',
-      events: {
-        dataPointSelection: function (event, chartContext, config) {
-          const selectedItem = targets[config.dataPointIndex];
-          itemSelected(selectedItem);
+    var options = {
+        series: [
+            {
+                name: 'Build time',
+                data: dataSeries
+            },
+            {
+                name: 'Compilation time',
+                data: compilationSeries
+            }
+        ],
+        chart: {
+            height: dataSeries.length * rowHeight,
+            type: 'rangeBar',
+            events: {
+                dataPointSelection: function (event, chartContext, config) {
+                    const selectedItem = targets[config.dataPointIndex];
+                    itemSelected(currentTarget, selectedItem);
+                }
+            }
+        },
+        plotOptions: {
+            bar: {
+                horizontal: true,
+                barHeight: '80%'
+            }
+        },
+        xaxis: {
+            type: 'datetime'
+        },
+        stroke: {
+            width: 1
+        },
+        fill: {
+            type: 'solid',
+            opacity: 0.6
+        },
+        legend: {
+            position: 'top',
+            horizontalAlign: 'left'
+        },
+        tooltip: {
+            enabled: true,
+            custom: function ({series, seriesIndex, dataPointIndex, w}) {
+                const serie = dataSeries[dataPointIndex];
+                const start = serie.start;
+                const end = serie.end;
+                const duration = (end - start).toFixed(3);
+                return '<div class="arrow_box">' +
+                    '<span>' + serie.x + ' </span><br>' +
+                    '<span>' + duration + ' seconds</span>' +
+                    '</div>'
+            },
+            y: {
+                enabled: true,
+                show: true,
+                formatter: undefined,
+                title: {
+                    formatter: (seriesName) => seriesName,
+                },
+            },
+
         }
-      }
-  },
-  plotOptions: {
-    bar: {
-      horizontal: true,
-      barHeight: '80%'
-    }
-  },
-  xaxis: {
-    type: 'datetime'
-  },
-  stroke: {
-    width: 1
-  },
-  fill: {
-    type: 'solid',
-    opacity: 0.6
-  },
-  legend: {
-    position: 'top',
-    horizontalAlign: 'left'
-  },
-  tooltip: {
-    enabled: true,
-    custom: function ({ series, seriesIndex, dataPointIndex, w }) {
-      const serie = dataSeries[dataPointIndex];
-      const start = serie.start;
-      const end = serie.end;
-      const duration = (end - start).toFixed(3);
-      return '<div class="arrow_box">' +
-        '<span>' + serie.x + ' </span><br>' +
-        '<span>' + duration + ' seconds</span>' +
-        '</div>'
-    },
-    y: {
-      enabled: true,
-      show: true,
-      formatter: undefined,
-      title: {
-        formatter: (seriesName) => seriesName,
-      },
-    },
+    };
 
-  }
-  };
-
-  var chart = new ApexCharts(document.querySelector("#timeline"), options);
-  chart.render();
+    var chart = new ApexCharts(document.querySelector("#timeline"), options);
+    chart.render();
 }
 
 function drawSlowestTargets(target) {
-  let clone = targets.slice(0);
-  const targetsData = clone.sort(function (lhs, rhs) {
-    return rhs.duration - lhs.duration
-  });
-  const top = Math.min(20, targetsData.length);
-  const topTargets = targetsData.slice(0, top);
-  const durations = topTargets.map(function (target) {
-    return target.duration.toFixed(3);
-  });
-  const names = topTargets.map(function (step) {
-    if (target === 'main') {
-      return step.title.replace('Build target ', '');
-    } else {
-      return getShortFilename(step.title, step.architecture);
-    }
-  });
-  const options = {
-    chart: {
-      height: names.length * rowHeight,
-      type: 'bar',
-      events: {
-        dataPointSelection: function (event, chartContext, config) {
-          const selectedItem = topTargets[config.dataPointIndex];
-          itemSelected(selectedItem);
+    let clone = targets.slice(0);
+    const targetsData = clone.sort(function (lhs, rhs) {
+        return rhs.duration - lhs.duration
+    });
+    const top = Math.min(20, targetsData.length);
+    const topTargets = targetsData.slice(0, top);
+    const durations = topTargets.map(function (target) {
+        return target.duration.toFixed(3);
+    });
+    const names = topTargets.map(function (step) {
+        if (target === 'main') {
+            return step.title.replace('Build target ', '');
+        } else {
+            return getShortFilename(step.title, step.architecture);
         }
-      }
-    },
-    plotOptions: {
-      bar: {
-        distributed: true,
-        horizontal: true
-      }
-    },
-    dataLabels: {
-      enabled: false
-    },
-    series: [{
-      data: durations
-    }],
-    xaxis: {
-      categories: names
-    },
-    legend: {
-      show: false
-    },
-    tooltip: {
-      y: {
-        title: {
-          formatter: function () {
-            return 'Seconds'
-          }
+    });
+    const options = {
+        chart: {
+            height: names.length * rowHeight,
+            type: 'bar',
+            events: {
+                dataPointSelection: function (event, chartContext, config) {
+                    const selectedItem = topTargets[config.dataPointIndex];
+                    itemSelected(target, selectedItem);
+                }
+            }
+        },
+        plotOptions: {
+            bar: {
+                distributed: true,
+                horizontal: true
+            }
+        },
+        dataLabels: {
+            enabled: false
+        },
+        series: [{
+            data: durations
+        }],
+        xaxis: {
+            categories: names
+        },
+        legend: {
+            show: false
+        },
+        tooltip: {
+            y: {
+                title: {
+                    formatter: function () {
+                        return 'Seconds'
+                    }
+                }
+            }
         }
-      }
     }
-  }
 
-  var chart = new ApexCharts(
-    document.querySelector("#bartargets"),
-    options
-  );
+    var chart = new ApexCharts(
+        document.querySelector("#bartargets"),
+        options
+    );
 
-  chart.render();
+    chart.render();
 }
 
 
-function drawSlowestFiles(collection, element) {
-  const sortedData = collection.sort(function (lhs, rhs) {
-    return rhs.duration - lhs.duration;
-  });
-  const top = Math.min(20, sortedData.length);
-  const topTargets = sortedData.slice(0, top);
-  const durations = topTargets.map(function (target) {
-    return target.duration.toFixed(3);
-  });
-  const names = topTargets.map(function (step) {
-    return getShortFilename(step.title, step.architecture);
-  });
-  const options = {
-    chart: {
-      height: names.length * rowHeight,
-      type: 'bar',
-      events: {
-        dataPointSelection: function (event, chartContext, config) {
-          const selectedItem = topTargets[config.dataPointIndex];
-          itemSelected(selectedItem);
+function drawSlowestFiles(collection, element, currentTarget) {
+    const sortedData = collection.sort(function (lhs, rhs) {
+        return rhs.duration - lhs.duration;
+    });
+    const top = Math.min(20, sortedData.length);
+    const topTargets = sortedData.slice(0, top);
+    const durations = topTargets.map(function (target) {
+        return target.duration.toFixed(3);
+    });
+    const names = topTargets.map(function (step) {
+        return getShortFilename(step.title, step.architecture);
+    });
+    const options = {
+        chart: {
+            height: names.length * rowHeight,
+            type: 'bar',
+            events: {
+                dataPointSelection: function (event, chartContext, config) {
+                    const selectedItem = topTargets[config.dataPointIndex];
+                    itemSelected(currentTarget, selectedItem);
+                }
+            }
+        },
+        plotOptions: {
+            bar: {
+                distributed: true,
+                horizontal: true
+            }
+        },
+        dataLabels: {
+            enabled: false
+        },
+        series: [{
+            data: durations
+        }],
+        xaxis: {
+            categories: names
+        },
+        legend: {
+            show: false
+        },
+        tooltip: {
+            y: {
+                title: {
+                    formatter: function () {
+                        return 'Seconds'
+                    }
+                }
+            }
         }
-      }
-    },
-    plotOptions: {
-      bar: {
-        distributed: true,
-        horizontal: true
-      }
-    },
-    dataLabels: {
-      enabled: false
-    },
-    series: [{
-      data: durations
-    }],
-    xaxis: {
-      categories: names
-    },
-    legend: {
-      show: false
-    },
-    tooltip: {
-      y: {
-        title: {
-          formatter: function () {
-            return 'Seconds'
-          }
-        }
-      }
     }
-  }
 
-  var chart = new ApexCharts(
-    document.querySelector(element),
-    options
-  );
+    var chart = new ApexCharts(
+        document.querySelector(element),
+        options
+    );
 
-  chart.render();
+    chart.render();
 }
 
 function getRequestedTarget() {
-  let name = "target"
-  if (name = (new RegExp('[?&]' + encodeURIComponent(name) + '=([^&]*)')).exec(location.search)) {
-    return decodeURIComponent(name[1]);
-  } else {
-    return "main"
-  }
+    return "{{target_name}}";
 }
 
 function getShortFilename(fileName, arch) {
-  if (fileName.includes('/')) {
-    const components = fileName.replace('Compile ', '').split('/');
-    const command = fileName.split(' ')[0]
-    const startIndex = Math.max(3, components.length - 3);
-    if (arch != '') {
-      return command + ' ' + arch + ' ' + components.slice(startIndex, components.length).join('/');
+    if (fileName.includes('/')) {
+        const components = fileName.replace('Compile ', '').split('/');
+        const command = fileName.split(' ')[0]
+        const startIndex = Math.max(3, components.length - 3);
+        if (arch != '') {
+            return command + ' ' + arch + ' ' + components.slice(startIndex, components.length).join('/');
+        }
+        return command + ' ' + components.slice(startIndex, components.length).join('/');
+    } else {
+        return fileName
     }
-    return command + ' ' + components.slice(startIndex, components.length).join('/');
-  } else {
-    return fileName
-  }
 }
 
 function drawErrors(target) {
-  $('#errors-count').html(mainStep.errorCount);
-  showErrors(target);
+    $('#errors-count').html(mainStep.errorCount);
+    showErrors(target);
 }
 
 function drawWarnings(target) {
-  $('#warnings-count').html(mainStep.warningCount);
-  showWarnings(target);
+    $('#warnings-count').html(mainStep.warningCount);
+    showWarnings(target);
 }
 
 function showErrors(target) {
-  const steps = target === 'main' ? buildData : targets;
-  const stepsWithErrors = steps.filter(function (step) {
-    return step.type != 'main' && step.type != 'target' && step.errorCount > 0;
-  }).sort(function (lhs, rhs) {
-    return rhs.warningCount - lhs.warningCount;
-  });
-  var summaries = '';
-  stepsWithErrors.forEach(function (step) {
-    const errorLegend = step.errorCount > 1 ? " errors in " : " error in ";
-    summaries += incidentTemplate({ "count": step.errorCount + errorLegend, "summary": step.signature, "details": step.errors });
-  });
-  $('#errors-summary').html(summaries);
-  if (stepsWithErrors.length > 0) {
-    $('#errors').show();
-  } else {
-    $('#errors').hide();
-  }
+    var stepsErrors;
+    if (target === 'main') {
+        stepsErrors = stepsWithErrors;
+    } else {
+        stepsErrors = targets.filter(function (step) {
+            return step.type != 'main' && step.type != 'target' && step.errorCount > 0;
+        }).sort(function (lhs, rhs) {
+            return rhs.errorCount - lhs.errorCount;
+        });
+    }
+    var summaries = '';
+    stepsErrors.forEach(function (step) {
+        const errorLegend = step.errorCount > 1 ? " errors in " : " error in ";
+        summaries += incidentTemplate({"count": step.errorCount + errorLegend, "summary": step.signature, "details": step.errors});
+    });
+    $('#errors-summary').html(summaries);
+    if (stepsErrors.length > 0) {
+        $('#errors').show();
+    } else {
+        $('#errors').hide();
+    }
 }
 
 function showWarnings(target) {
-  const steps = target === 'main' ? buildData : targets;
-  const stepsWithWarnings = steps.filter(function (step) {
-    return step.warnings.length > 0;
-  }).sort(function (lhs, rhs) {
-    return rhs.warningCount - lhs.warningCount;
-  });
-  var summaries = '';
-  stepsWithWarnings.forEach(function (step) {
-    if (step.warnings.length > 0) {
-      const warningLegend = step.warningCount > 1 ? " warnings in " : " warning in ";
-      summaries += incidentTemplate({ "count": step.warningCount + warningLegend, "summary": step.signature, "details": step.warnings });
+    var stepsWarnings;
+    if (target === 'main') {
+        stepsWarnings = stepsWithWarnings;
+    } else {
+        stepsWarnings = buildData.filter(function (step) {
+            return step.type != 'target' && step.warningCount > 0;
+        }).sort(function (lhs, rhs) {
+            return rhs.errorCount - lhs.errorCount;
+        });
     }
-  });
-  $('#warnings-summary').html(summaries);
-  if (stepsWithWarnings.length > 0) {
-    $('#warnings').show();
-  } else {
-    $('#warnings').hide();
-  }
+    var summaries = '';
+    stepsWarnings.forEach(function (step) {
+        if (step.warnings.length > 0) {
+            const warningLegend = step.warningCount > 1 ? " warnings in " : " warning in ";
+            summaries += incidentTemplate({"count": step.warningCount + warningLegend, "summary": step.signature, "details": step.warnings});
+        }
+    });
+    $('#warnings-summary').html(summaries);
+    if (stepsWarnings.length > 0) {
+        $('#warnings').show();
+    } else {
+        $('#warnings').hide();
+    }
 }
 
-function itemSelected(selectedItem) {
-  if (selectedItem.type === 'target') {
-    window.location.href = window.location.href + "?target=" + selectedItem.identifier;
-  } else if (selectedItem.type === 'detail') {
-    const stepUrl = window.location.href.replace('index.html', 'step.html');
-    window.location.href =  stepUrl + "?step=" + selectedItem.identifier;
-  }
+function itemSelected(target, selectedItem) {
+    if (selectedItem.type === 'target') {
+        const fileName = selectedItem.identifier.replaceAll(' ', '_');
+        window.location.href = window.location.href.replace('index.html', fileName + '.html');
+    } else if (selectedItem.type === 'detail') {
+        const targetId = selectedItem.parentIdentifier.replaceAll(' ', '_');
+        if (target === 'main') {
+            const stepUrl = window.location.href.replace(encodeURI('{{file_name}}'), targetId + '.html');
+            window.location.href = stepUrl + "?step=" + selectedItem.identifier;
+        } else {
+            const stepUrl = window.location.href.replace(encodeURI('{{file_name}}'), '{{steps_name}}');
+            window.location.href = stepUrl + "?step=" + selectedItem.identifier;
+        }
+    }
 }
 
 function drawSwiftFunctions(target) {
-  const steps = target === 'main' ? buildData : targets;
-  const swiftFunctions = steps.filter(function (step) {
-    return step.swiftFunctionTimes && step.swiftFunctionTimes.length > 0;
-  }).flatMap(function (step) {
-    return step.swiftFunctionTimes
-  }).map(function(f) {
-    f.cumulative = Math.round(f.occurrences * f.durationMS * 100) / 100;
-    return f;
-  }).sort(function (lhs, rhs) {
-    return rhs.durationMS - lhs.durationMS;
-  });
-  if (swiftFunctions.length > 0) {
-    const functions = swiftFunctionTemplate({"functions": swiftFunctions});
-    $('#swiftfunctions').html(functions);
-    $('#swift-functions-table').DataTable({
-      "info": false,
-      "scrollX": true,
-      "order": [[ 0, "desc" ]]
+    let swiftFunctions;
+    if (target === 'main') {
+        swiftFunctions = topSwiftFunctions;
+    } else {
+        swiftFunctions = targets.filter(function (step) {
+            return step.swiftFunctionTimes && step.swiftFunctionTimes.length > 0;
+        }).flatMap(function (step) {
+            return step.swiftFunctionTimes
+        });
+    }
+
+    const cumulativeSwiftFunctions = swiftFunctions.map(function (f) {
+        f.cumulative = Math.round(f.occurrences * f.durationMS * 100) / 100;
+        return f;
     });
-  } else {
-    $('#swiftfunctions').html(swiftFunctionWarning);
-  }
+    if (cumulativeSwiftFunctions.length > 0) {
+        const functions = swiftFunctionTemplate({"functions": cumulativeSwiftFunctions});
+        $('#swiftfunctions').html(functions);
+        $('#swift-functions-table').DataTable({
+            "info": false,
+            "scrollX": true,
+            "order": [[0, "desc"]]
+        });
+    } else {
+        $('#swiftfunctions').html(swiftFunctionWarning);
+    }
 }
 
 function drawSwiftTypeChecks(target) {
-  const steps = target === 'main' ? buildData : targets;
-  const swiftTypeCheckTimes = steps.filter(function (step) {
-    return step.swiftTypeCheckTimes && step.swiftTypeCheckTimes.length > 0;
-  }).flatMap(function (step) {
-    return step.swiftTypeCheckTimes
-  }).map(function(f) {
-    f.cumulative = Math.round(f.occurrences * f.durationMS * 100) / 100;
-    return f;
-  }).sort(function (lhs, rhs) {
-    return rhs.durationMS - lhs.durationMS;
-  });
-  if (swiftTypeCheckTimes.length > 0) {
-    const functions = swiftTypeCheckTemplate({"functions": swiftTypeCheckTimes});
-    $('#swifttypechecks').html(functions);
-    $('#swift-typechecks-table').DataTable({
-      "info": false,
-      "scrollX": true,
-      "order": [[ 0, "desc" ]]
+    let swiftTypeCheckTimes;
+    if (target === 'main') {
+        swiftTypeCheckTimes = topSwifTypeChecks;
+    } else {
+        swiftTypeCheckTimes = targets.filter(function (step) {
+            return step.swiftTypeCheckTimes && step.swiftTypeCheckTimes.length > 0;
+        }).flatMap(function (step) {
+            return step.swiftTypeCheckTimes
+        });
+    }
+
+    const cumulativeSwiftTypeCheckTimes = swiftTypeCheckTimes.map(function (f) {
+        f.cumulative = Math.round(f.occurrences * f.durationMS * 100) / 100;
+        return f;
     });
-  } else {
-    $('#swifttypechecks').html(swiftTypeCheckWarning);
-  }
+    if (swiftTypeCheckTimes.length > 0) {
+        const functions = swiftTypeCheckTemplate({"functions": cumulativeSwiftTypeCheckTimes});
+        $('#swifttypechecks').html(functions);
+        $('#swift-typechecks-table').DataTable({
+            "info": false,
+            "scrollX": true,
+            "order": [[0, "desc"]]
+        });
+    } else {
+        $('#swifttypechecks').html(swiftTypeCheckWarning);
+    }
 }
 
 """
@@ -1029,11 +1040,13 @@ public static let indexHTML =
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.1.2/handlebars.min.js"></script>
-  <script type="text/javascript" src="js/build.js"></script>
+  <script type="text/javascript" src="js/{{data_file}}"></script>
+  <script type="text/javascript" src="js/errors_warnings.js"></script>
+  <script type="text/javascript" src="js/top_files.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.23.0/moment-with-locales.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
-  <script type="text/javascript" src="js/app.js"></script>
+    <script type="text/javascript" src="js/{{app_file}}"></script>
 </body>
 </html>
 
@@ -1289,7 +1302,7 @@ public static let stepHTML =
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.1.2/handlebars.min.js"></script>
-  <script type="text/javascript" src="js/build.js"></script>
+      <script type="text/javascript" src="js/{{data_file}}"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.23.0/moment-with-locales.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script type="text/javascript" src="js/step.js"></script>

--- a/Sources/XCLogParser/parser/BuildStep+Builder.swift
+++ b/Sources/XCLogParser/parser/BuildStep+Builder.swift
@@ -257,6 +257,39 @@ extension BuildStep {
                          linkerStatistics: linkerStatistics)
     }
 
+    func with(parentIdentifier newParentIdentifier: String) -> BuildStep {
+        return BuildStep(type: type,
+                         machineName: machineName,
+                         buildIdentifier: buildIdentifier,
+                         identifier: identifier,
+                         parentIdentifier: newParentIdentifier,
+                         domain: domain,
+                         title: title,
+                         signature: signature,
+                         startDate: startDate,
+                         endDate: endDate,
+                         startTimestamp: startTimestamp,
+                         endTimestamp: endTimestamp,
+                         duration: duration,
+                         detailStepType: detailStepType,
+                         buildStatus: buildStatus,
+                         schema: schema,
+                         subSteps: subSteps,
+                         warningCount: warningCount,
+                         errorCount: errorCount,
+                         architecture: architecture,
+                         documentURL: documentURL,
+                         warnings: warnings,
+                         errors: errors,
+                         notes: notes,
+                         swiftFunctionTimes: swiftFunctionTimes,
+                         fetchedFromCache: fetchedFromCache,
+                         compilationEndTimestamp: compilationEndTimestamp,
+                         compilationDuration: compilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics)
+    }
+
     private func filterNotices(_ notices: [Notice]?) -> [Notice]? {
         guard let notices = notices else {
             return nil

--- a/Sources/XCLogParser/reporter/HtmlReporter.swift
+++ b/Sources/XCLogParser/reporter/HtmlReporter.swift
@@ -23,23 +23,27 @@ import Foundation
 /// It uses the html and javascript files from the Resources folder as templates
 public struct HtmlReporter: LogReporter {
 
+    /// Max number of Swift Type and Function Checks to present in the
+    /// main index file
+    static let maxSwifTypeChecks = 1_000
+
+    /// Max number of slowest files to present in the main index file
+    static let maxSlowestFiles = 20
+
     public func report(build: Any, output: ReporterOutput, rootOutput: String) throws {
         guard let steps = build as? BuildStep else {
             throw XCLogParserError.errorCreatingReport("Type not supported \(type(of: build))")
         }
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        let json = try encoder.encode(steps.flatten())
-        guard let jsonString = String(data: json, encoding: .utf8) else {
-            throw  XCLogParserError.errorCreatingReport("Can't generate the JSON file.")
-        }
-        try writeHtmlReport(for: steps, jsonString: jsonString, output: output, rootOutput: rootOutput)
+        let buildDir = try createDir(for: steps, output: output, rootOutput: rootOutput)
+        try writeMainFiles(build: steps, toDir: buildDir)
+        try writeTargetFiles(build: steps, toDir: buildDir)
+        try writeSharedResources(toDir: buildDir)
+        print("Report written to \(buildDir)/index.html")
     }
 
-    private func writeHtmlReport(for build: BuildStep,
-                                 jsonString: String,
-                                 output: ReporterOutput,
-                                 rootOutput: String) throws {
+    private func createDir(for build: BuildStep,
+                           output: ReporterOutput,
+                           rootOutput: String) throws -> String {
         var path = "build/xclogparser/reports"
         if let output = output as? FileOutput {
             path = output.path
@@ -60,19 +64,211 @@ public struct HtmlReporter: LogReporter {
             atPath: "\(buildDir)/js",
             withIntermediateDirectories: true,
             attributes: nil)
-        try HtmlReporterResources.css.write(toFile: "\(buildDir)/css/styles.css", atomically: true, encoding: .utf8)
-        try HtmlReporterResources.appJS.write(toFile: "\(buildDir)/js/app.js", atomically: true, encoding: .utf8)
-        try HtmlReporterResources.indexHTML.write(toFile: "\(buildDir)/index.html", atomically: true, encoding: .utf8)
-        try HtmlReporterResources.stepJS.write(toFile: "\(buildDir)/js/step.js", atomically: true, encoding: .utf8)
-        try HtmlReporterResources.stepHTML.write(toFile: "\(buildDir)/step.html", atomically: true, encoding: .utf8)
-        let jsContent = HtmlReporterResources.buildJS.replacingOccurrences(of: "{{build}}", with: jsonString)
-        try jsContent.write(toFile: "\(buildDir)/js/build.js", atomically: true, encoding: .utf8)
-        print("Report written to \(buildDir)/index.html")
+        return buildDir
     }
 
     private func dirFor(build: BuildStep) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "YYYYMMddHHmmss"
         return dateFormatter.string(from: Date(timeIntervalSince1970: Double(build.startTimestamp)))
+    }
+
+    /// Writes the HMTL and JS files of the main summary page. The one with the summary of the whole build
+    private func writeMainFiles(build: BuildStep, toDir buildDir: String) throws {
+        let targetsNoSteps = build.subSteps.map { target -> BuildStep in
+            let noSteps = target.with(subSteps: [])
+            return noSteps
+        }
+        let updatedBuild = build.with(subSteps: targetsNoSteps).flatten()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+
+        let json = try encoder.encode(updatedBuild)
+        guard let jsonString = String(data: json, encoding: .utf8) else {
+            throw  XCLogParserError.errorCreatingReport("Can't generate the Targets JSON files.")
+        }
+        let jsContent = HtmlReporterResources.buildJS.replacingOccurrences(of: "{{build}}", with: jsonString)
+        try jsContent.write(toFile: "\(buildDir)/js/targets.js", atomically: true, encoding: .utf8)
+
+        let appJSContent = HtmlReporterResources.appJS
+            .replacingOccurrences(of: "{{target_name}}", with: "main")
+            .replacingOccurrences(of: "{{file_name}}",
+                                  with: "index.html")
+            .replacingOccurrences(of: "{{steps_name}}",
+                                  with: "step.html")
+
+        try appJSContent.write(toFile: "\(buildDir)/js/app.js", atomically: true, encoding: .utf8)
+
+        let htmlContent = HtmlReporterResources.indexHTML
+            .replacingOccurrences(of: "{{data_file}}", with: "targets.js")
+            .replacingOccurrences(of: "{{app_file}}", with: "app.js")
+        try htmlContent.write(toFile: "\(buildDir)/index.html", atomically: true, encoding: .utf8)
+        try writeTopFiles(build: build, toDir: buildDir)
+    }
+
+    /// Writes the HTML and JS for earch target in the build.
+    // swiftlint:disable:next function_body_length
+    private func writeTargetFiles(build: BuildStep, toDir buildDir: String) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        var stepsWithErrors: [BuildStep] = []
+        var stepsWithWarnings: [BuildStep] = []
+        try build.subSteps.forEach { target in
+            stepsWithErrors.append(contentsOf: getStepsWithErrors(target: target))
+            stepsWithWarnings.append(contentsOf: getStepsWithWarnings(target: target))
+            let targetName = target.identifier.replacingOccurrences(of: " ", with: "_")
+            let name = "\(targetName).js"
+            let json = try encoder.encode(target.flatten())
+            guard let jsonString = String(data: json, encoding: .utf8) else {
+                throw  XCLogParserError.errorCreatingReport("Can't generate the Targets JSON files.")
+            }
+            let targetContent = "const buildData = \(jsonString);"
+            try targetContent.write(toFile: "\(buildDir)/js/\(name)", atomically: true, encoding: .utf8)
+
+            let appJSContent = HtmlReporterResources.appJS
+                .replacingOccurrences(of: "{{target_name}}",
+                                      with: target.identifier)
+                .replacingOccurrences(of: "{{file_name}}",
+                                      with: "\(targetName).html")
+                .replacingOccurrences(of: "{{steps_name}}",
+                                      with: "step_\(targetName).html")
+            try appJSContent.write(toFile: "\(buildDir)/js/\(targetName)_app.js", atomically: true, encoding: .utf8)
+
+            let htmlContent = HtmlReporterResources.indexHTML
+                .replacingOccurrences(of: "{{data_file}}", with: "\(targetName).js")
+                .replacingOccurrences(of: "{{app_file}}", with: "\(targetName)_app.js")
+            try htmlContent.write(toFile: "\(buildDir)/\(targetName).html", atomically: true, encoding: .utf8)
+
+            let stepHtmlContent = HtmlReporterResources.stepHTML
+                .replacingOccurrences(of: "{{data_file}}", with: "\(targetName).js")
+            try stepHtmlContent.write(toFile: "\(buildDir)/step_\(targetName).html",
+                                      atomically: true,
+                                      encoding: .utf8)
+        }
+        let jsonErrors = try encoder.encode(stepsWithErrors)
+        let jsonWarnings = try encoder.encode(stepsWithWarnings)
+        guard let errors = String(data: jsonErrors, encoding: .utf8),
+              let warnings = String(data: jsonWarnings, encoding: .utf8) else {
+            throw  XCLogParserError.errorCreatingReport("Can't generate the Issues JSON file.")
+        }
+        let errorsContent = "const stepsWithErrors = \(errors);"
+        let warningsContent = "const stepsWithWarnings = \(warnings);"
+        let issuesContent = "\(errorsContent)\n\(warningsContent)"
+        try issuesContent.write(toFile: "\(buildDir)/js/errors_warnings.js",
+                                atomically: true,
+                                encoding: .utf8)
+    }
+
+    private func writeSharedResources(toDir buildDir: String) throws {
+        try HtmlReporterResources.css.write(toFile: "\(buildDir)/css/styles.css", atomically: true, encoding: .utf8)
+        try HtmlReporterResources.stepJS.write(toFile: "\(buildDir)/js/step.js", atomically: true, encoding: .utf8)
+        try HtmlReporterResources.stepHTML.write(toFile: "\(buildDir)/step.html", atomically: true, encoding: .utf8)
+    }
+
+    private func getStepsWithErrors(target: BuildStep) -> [BuildStep] {
+        return Array(target.subSteps.map { step -> [BuildStep] in
+            var stepsWithErrors: [BuildStep] = []
+            if step.detailStepType != .swiftAggregatedCompilation && step.errorCount > 0 {
+                stepsWithErrors.append(step)
+            }
+            stepsWithErrors.append(contentsOf: step.subSteps.filter { $0.errorCount > 0 })
+            return stepsWithErrors
+        }.joined())
+
+    }
+
+    private func getStepsWithWarnings(target: BuildStep) -> [BuildStep] {
+        return Array(target.subSteps.map { step -> [BuildStep] in
+            var stepsWithWarnings: [BuildStep] = []
+            if step.detailStepType != .swiftAggregatedCompilation && step.warningCount > 0 {
+                stepsWithWarnings.append(step)
+            }
+            stepsWithWarnings.append(contentsOf: step.subSteps.filter { $0.warningCount > 0 })
+            return stepsWithWarnings
+        }.joined())
+    }
+
+    /// Precomputes and Writes the top slowest files and Swift Type checks
+    /// of the whole build.
+    private func writeTopFiles(build: BuildStep, toDir buildDir: String) throws {
+        let steps = build.subSteps.map { $0.subSteps }.joined()
+        let aggretatedAndSwiftSteps = steps.filter { !$0.fetchedFromCache &&
+            ($0.detailStepType == .swiftCompilation || $0.detailStepType == .swiftAggregatedCompilation) }
+        var swiftFunctionTimes: [SwiftFunctionTime] = []
+        var swiftTypeCheckTimes: [SwiftTypeCheck] = []
+        var swiftSteps: [BuildStep] = []
+
+        aggretatedAndSwiftSteps.forEach { step in
+            if step.detailStepType == .swiftAggregatedCompilation {
+                let swiftSubSteps = step.subSteps.filter { $0.detailStepType == .swiftCompilation}
+                    .map { subStep in
+                        subStep.with(parentIdentifier: step.parentIdentifier)
+                    }
+                swiftSteps.append(contentsOf: swiftSubSteps)
+                let functions = swiftSubSteps
+                    .compactMap { $0.swiftFunctionTimes }
+                    .joined()
+                let typeChecks = swiftSubSteps
+                    .compactMap { $0.swiftTypeCheckTimes }
+                    .joined()
+                swiftFunctionTimes.append(contentsOf: functions)
+                swiftTypeCheckTimes.append(contentsOf: typeChecks)
+            } else {
+                swiftSteps.append(step)
+                if let functions = step.swiftFunctionTimes {
+                    swiftFunctionTimes.append(contentsOf: functions)
+                }
+                if let typeChecks = step.swiftTypeCheckTimes {
+                    swiftTypeCheckTimes.append(contentsOf: typeChecks)
+                }
+            }
+        }
+
+        swiftSteps.sort { $0.compilationDuration > $1.compilationDuration }
+        let cSteps = steps.filter { !$0.fetchedFromCache && $0.detailStepType == .cCompilation }
+            .sorted { $0.compilationDuration > $1.compilationDuration }
+
+        swiftFunctionTimes.sort { $0.durationMS > $1.durationMS }
+        let topFunctions = Array(swiftFunctionTimes.prefix(Self.maxSwifTypeChecks))
+
+        swiftTypeCheckTimes.sort { $0.durationMS > $1.durationMS }
+        let topTypeChecks = Array(swiftTypeCheckTimes.prefix(Self.maxSwifTypeChecks))
+
+        try write(
+            slowestSwiftFiles: Array(swiftSteps.prefix(Self.maxSlowestFiles)),
+            slowestCFiles: Array(cSteps.prefix(Self.maxSlowestFiles)),
+            swiftFunctionTimes: topFunctions,
+            swiftTypeCheckTimes: topTypeChecks,
+            toDir: buildDir)
+
+    }
+
+    private func write(slowestSwiftFiles: [BuildStep],
+                       slowestCFiles: [BuildStep],
+                       swiftFunctionTimes: [SwiftFunctionTime],
+                       swiftTypeCheckTimes: [SwiftTypeCheck],
+                       toDir buildDir: String) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let functionsJson = try encoder.encode(swiftFunctionTimes)
+        let typeChecksJson = try encoder.encode(swiftTypeCheckTimes)
+        let swiftJson = try encoder.encode(slowestSwiftFiles)
+        let cJson = try encoder.encode(slowestCFiles)
+        guard let functionsString = String(data: functionsJson, encoding: .utf8),
+              let typeChecksString = String(data: typeChecksJson, encoding: .utf8),
+              let swiftString = String(data: swiftJson, encoding: .utf8),
+              let cString = String(data: cJson, encoding: .utf8)
+        else {
+            throw  XCLogParserError.errorCreatingReport("Can't generate the Swift Type Checks JSON files.")
+        }
+        try """
+        const cSlowestFiles = \(cString);
+
+        const swiftSlowestFiles = \(swiftString);
+
+        const topSwiftFunctions = \(functionsString);
+
+        const topSwifTypeChecks = \(typeChecksString);
+        """.write(toFile: "\(buildDir)/js/top_files.js", atomically: true, encoding: .utf8)
     }
 }


### PR DESCRIPTION
Currently the generated `json` file can be too big to be parsed by the browser as reported in [Issue 108](https://github.com/spotify/XCLogParser/issues/108).

This PR breaks it down in smaller html/json files. One per target. It also pre computes the slowest compilation files and Swift Type checks to present them in the main summary. As a drawback, we generate more files, but the rendering in the browser is way much faster for large builds.