### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build
         run: rake build[release]
       - name: Set tag name
-        run: echo ::set-env name=TAG_NAME::$(echo $GITHUB_REF | cut -c 11-)
+        run: echo "TAG_NAME=$(echo $GITHUB_REF | cut -c 11-)" >> $GITHUB_ENV
       - name: Zip release
         run: "mkdir releases && zip -j releases/XCLogParser-macOS-x86_64-$TAG_NAME.zip .build/release/xclogparser"
       - name: Upload binaries to release
@@ -42,7 +42,7 @@ jobs:
       - name: Build
         run: LANG=en_US.UTF-8 LC_CTYPE=UTF-8 rake build[release]
       - name: Set tag name
-        run: echo ::set-env name=TAG_NAME::$(echo $GITHUB_REF | cut -c 11-)
+        run: echo "TAG_NAME=$(echo $GITHUB_REF | cut -c 11-)" >> $GITHUB_ENV
       - name: Zip release
         uses: montudor/action-zip@v0.1.0
         with:

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.20"
+    public static let current = "0.2.21"
 
 }


### PR DESCRIPTION
The Release Job is failing with the message
```
The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This PR changes the CI job to use the new way to setup env vars using [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files). Hopefully that will work, since there is no way to test this locally