### PR TITLE
Show root errors in HTML report

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.21"
+    public static let current = "0.2.22"
 
 }

--- a/Sources/XCLogParser/reporter/HtmlReporter.swift
+++ b/Sources/XCLogParser/reporter/HtmlReporter.swift
@@ -113,6 +113,12 @@ public struct HtmlReporter: LogReporter {
         encoder.outputFormatting = .prettyPrinted
         var stepsWithErrors: [BuildStep] = []
         var stepsWithWarnings: [BuildStep] = []
+        if let buildErrors = build.errors, buildErrors.count > 0 {
+            stepsWithErrors.append(build.with(subSteps: []))
+        }
+        if let buildWarnings = build.warnings, buildWarnings.count > 0 {
+            stepsWithWarnings.append(build.with(subSteps: []))
+        }
         try build.subSteps.forEach { target in
             stepsWithErrors.append(contentsOf: getStepsWithErrors(target: target))
             stepsWithWarnings.append(contentsOf: getStepsWithWarnings(target: target))


### PR DESCRIPTION
Fixes https://github.com/spotify/XCLogParser/issues/113

If there were errors or warnings at the root level, the HTML reports was not showing them.
