### PR TITLE
Add macOS arm64 and fat executable deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     container:
-      image: swift:5.1
+      image: swift:5.2
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   macOS:
     runs-on: macOS-latest
     env:
-      XCODE_VERSION: ${{ '11.4' }}
+      XCODE_VERSION: ${{ '12.2' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,24 @@ jobs:
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Build
-        run: rake build[release]
       - name: Set tag name
         run: echo "TAG_NAME=$(echo $GITHUB_REF | cut -c 11-)" >> $GITHUB_ENV
-      - name: Zip release
+      - name: Build x86_64-apple-macosx
+        run: rake 'build[release, x86_64-apple-macosx]'
+      - name: Zip x86_64-apple-macosx release
         run: "mkdir releases && zip -j releases/XCLogParser-macOS-x86_64-$TAG_NAME.zip .build/release/xclogparser"
+      - name: Save x86_64 executable to be lipo'd later
+        run: mkdir tmp && cp .build/release/xclogparser tmp/xclogparser-x86_64
+      - name: Zip x86_64-apple-macosx release
+        run: "mkdir releases && zip -j releases/XCLogParser-macOS-x86_64-$TAG_NAME.zip .build/release/xclogparser"
+      - name: Build arm64-apple-macosx
+        run: rake 'build[release, arm64-apple-macosx]'
+      - name: Zip arm64-apple-macosx release
+        run: "zip -j releases/XCLogParser-macOS-arm64-$TAG_NAME.zip .build/release/xclogparser"
+      - name: Lipo macOS executables
+        run: "lipo -create -output tmp/xclogparser tmp/xclogparser-x86_64 .build/release/xclogparser"
+      - name: Zip x86_64-arm64-apple-macosx release
+        run: "zip -j releases/XCLogParser-macOS-x86-64-arm64-$TAG_NAME.zip tmp/xclogparser"
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v1-release
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     name: Add Linux binaries to release
     runs-on: ubuntu-latest
     container:
-      image: swift:5.1
+      image: swift:5.2
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Add macOS binaries to release
     runs-on: macOS-latest
     env:
-      XCODE_VERSION: ${{ '11.4' }}
+      XCODE_VERSION: ${{ '12.2' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ INSTALLATION_PREFIX = '/usr/local'.freeze
 
 
 desc 'Build XCLogParser'
-task :build, [:configuration, :sdks, :is_archive] => ['gen_resources'] do |task, args|
+task :build, [:configuration, :arch, :sdks, :is_archive] => ['gen_resources'] do |task, args|
   # Set task defaults
   args.with_defaults(:configuration => 'debug', :sdks => ['macos'])
 
@@ -27,7 +27,7 @@ task :build, [:configuration, :sdks, :is_archive] => ['gen_resources'] do |task,
   # Build
   build_paths = []
   args.sdks.each do |sdk|
-    spm_build(args.configuration)
+    spm_build(args.configuration, args.arch)
     # path of the executable looks like: `.build/(debug|release)/xclogparser`
     build_path = File.join(BUILD_DIR, args.configuration, EXECUTABLE_NAME)
     build_paths.push(build_path)
@@ -70,9 +70,10 @@ end
 # Helper functions
 ################################
 
-def spm_build(configuration)
+def spm_build(configuration, arch)
   spm_cmd = "swift build "\
             "-c #{configuration} "\
+            "#{arch.nil? ? "" : "--triple #{arch}"}"\
             "--disable-sandbox"
   p spm_cmd
   system(spm_cmd) or abort "Build failure"


### PR DESCRIPTION
This PR also has a bunch of improvements, such as moving CI to Xcode 12.2 (required to build for arm64) as well as moving the Linux CI to Swift 5.2.