### PR TITLE
Omit warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Example output available in the [reporters](#reporters) section.
   | `--without_build_specific_info`  | If specified, build specific information will be removed from the logs (for example `bolnckhlbzxpxoeyfujluasoupft` will be removed from  `DerivedData/Product-bolnckhlbzxpxoeyfujluasoupft/Build` ). Useful for grouping logs by its content.  | No |
   | `--strictProjectName`  | Used in conjunction with `--project`. If specified, a stricter name matching will be done for the project name.  | No |
   | `--machine_name`  | If specified, the machine name will be used to create the `buildIdentifier`. If it is not specified, the host name will be used.  | No |
+  | `--omit_warnings` | Omit the warnings details in the final report. This is useful if there are too many of them and the report's size is too big with them. | No |
 
   >No *: One of `--file`, `--project`, `--workspace`, `--xcodeproj` parameters is required.
 

--- a/Sources/XCLogParser/commands/ActionOptions.swift
+++ b/Sources/XCLogParser/commands/ActionOptions.swift
@@ -46,17 +46,22 @@ public struct ActionOptions {
     /// The rootOutput will generate the HTML output in the given folder
     public let rootOutput: String
 
+    /// If true, the parse command won't add the Warnings details to the output.
+    public let omitWarningsDetails: Bool
+
     public init(reporter: Reporter,
                 outputPath: String,
                 redacted: Bool,
                 withoutBuildSpecificInformation: Bool,
                 machineName: String? = nil,
-                rootOutput: String = "") {
+                rootOutput: String = "",
+                omitWarningsDetails: Bool = false) {
         self.reporter = reporter
         self.outputPath = outputPath
         self.redacted = redacted
         self.withoutBuildSpecificInformation = withoutBuildSpecificInformation
         self.machineName = machineName
         self.rootOutput = rootOutput
+        self.omitWarningsDetails = omitWarningsDetails
     }
 }

--- a/Sources/XCLogParser/commands/CommandHandler.swift
+++ b/Sources/XCLogParser/commands/CommandHandler.swift
@@ -60,8 +60,11 @@ public struct CommandHandler {
     func handleParse(fromLogURL logURL: URL, options: ActionOptions) throws {
         let activityLog = try activityLogParser.parseActivityLogInURL(logURL,
                                                                       redacted: options.redacted,
-                                                                      withoutBuildSpecificInformation: options.withoutBuildSpecificInformation) // swiftlint:disable:this line_length
-        let buildParser = ParserBuildSteps(machineName: options.machineName)
+                                                                      withoutBuildSpecificInformation:
+                                                                        options.withoutBuildSpecificInformation)
+
+        let buildParser = ParserBuildSteps(machineName: options.machineName,
+                                           omitWarningsDetails: options.omitWarningsDetails)
         let buildSteps = try buildParser.parse(activityLog: activityLog)
         let reporterOutput = ReporterOutputFactory.makeReporterOutput(path: options.outputPath)
         let logReporter = options.reporter.makeLogReporter()

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.22"
+    public static let current = "0.2.23"
 
 }

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -34,6 +34,10 @@ public final class ParserBuildSteps {
     let swiftCompilerParser = SwiftCompilerParser()
     let clangCompilerParser = ClangCompilerParser()
 
+    /// If true, the details of Warnings won't be added.
+    /// Useful to save space.
+    let omitWarningsDetails: Bool
+
     public lazy var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.timeZone = TimeZone(abbreviation: "UTC")
@@ -69,12 +73,13 @@ public final class ParserBuildSteps {
 
     /// - parameter machineName: The name of the machine. It will be used to create a unique identifier
     /// for the log. If `nil`, the host name will be used instead.
-    public init(machineName: String? = nil) {
+    public init(machineName: String? = nil, omitWarningsDetails: Bool) {
         if let machineName = machineName {
             self.machineName = machineName
         } else {
             self.machineName = MacOSMachineNameReader().machineName ?? "unknown"
         }
+        self.omitWarningsDetails = omitWarningsDetails
     }
 
     /// Parses the content from an Xcode log into a `BuildStep`
@@ -147,7 +152,7 @@ public final class ParserBuildSteps {
                                  errorCount: errorCount,
                                  architecture: parseArchitectureFromLogSection(logSection, andType: detailType),
                                  documentURL: logSection.location.documentURLString,
-                                 warnings: warnings,
+                                 warnings: omitWarningsDetails ? [] : warnings,
                                  errors: errors,
                                  notes: notes,
                                  swiftFunctionTimes: nil,

--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -107,6 +107,13 @@ struct ParseCommand: ParsableCommand {
     """)
     var rootOutput: String?
 
+    @Flag(name: .customLong("omit_warnings"),
+          help: """
+    If present, the report will omit the Warnings found in the log.
+    Useful to reduce the size of the final report.
+    """)
+    var omitWarnings: Bool = false
+
     mutating func validate() throws {
         if !hasValidLogOptions() {
             throw ValidationError("""
@@ -147,7 +154,8 @@ struct ParseCommand: ParsableCommand {
                                           redacted: redacted,
                                           withoutBuildSpecificInformation: withoutBuildSpecificInformation,
                                           machineName: machineName,
-                                          rootOutput: rootOutput ?? "")
+                                          rootOutput: rootOutput ?? "",
+                                          omitWarningsDetails: omitWarnings)
         let action = Action.parse(options: actionOptions)
         let command = Command(logOptions: logOptions, action: action)
         try commandHandler.handle(command: command)


### PR DESCRIPTION
Solves [Issue 117] (https://github.com/spotify/XCLogParser/issues/117) by adding a new flag to `parse` to avoid adding the warnings details to the final report

