### PR TITLE
Fix missing errors on xcodebuild logs

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.23"
+    public static let current = "0.2.24"
 
 }

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -56,7 +56,6 @@ extension Notice {
             if var notice = Notice(withType: NoticeType.fromTitle(noticeTypeTitle),
                                    logMessage: message,
                                    detail: logSection.text) {
-
                 // Add the right details to Swift errors
                 if notice.type == NoticeType.swiftError || notice.type == .swiftWarning {
                     // Special case, if Swiftc fails for a whole module,
@@ -68,7 +67,7 @@ extension Notice {
                         errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
                         // do not report error in a file that it does not belong to (we'll ended
                         // up having duplicated errors)
-                        if logSection.location.documentURLString != notice.documentURL {
+                        if !logSection.location.documentURLString.isEmpty && logSection.location.documentURLString != notice.documentURL {
                             return nil
                         }
                         notice = notice.with(detail: swiftErrorDetails[errorLocation])

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -67,7 +67,8 @@ extension Notice {
                         errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
                         // do not report error in a file that it does not belong to (we'll ended
                         // up having duplicated errors)
-                        if !logSection.location.documentURLString.isEmpty && logSection.location.documentURLString != notice.documentURL {
+                        if !logSection.location.documentURLString.isEmpty
+                            && logSection.location.documentURLString != notice.documentURL {
                             return nil
                         }
                         notice = notice.with(detail: swiftErrorDetails[errorLocation])


### PR DESCRIPTION
When using `xcodebuild` some Swift errors were not being reported, this fixes the issue.