### PR TITLE
Show Swift Type Checks in HTML Report

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "5669f222e46c8134fb1f399c745fa6882b43532e",
-          "version": "1.3.8"
+          "revision": "e2bc81be54d71d566a52ca17c3983d141c30aa70",
+          "version": "1.3.3"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "90e5b7af823d869fa8dea5a3abc7d95b6cb04c8c",
-          "version": "1.1.3"
+          "revision": "5669f222e46c8134fb1f399c745fa6882b43532e",
+          "version": "1.3.8"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/1024jp/GzipSwift", from: "5.1.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.8"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("1.3.3")),
         .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
         .library(name: "XCLogParser", targets: ["XCLogParser"])
     ],
     dependencies: [
-        .package(url: "https://github.com/1024jp/GzipSwift", from: "5.1.0"),        
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.0.0"),
+        .package(url: "https://github.com/1024jp/GzipSwift", from: "5.1.0"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.8"),
         .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
     ],

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.26"
+    public static let current = "0.2.27"
 
 }

--- a/Sources/XCLogParser/parser/BuildStep+Builder.swift
+++ b/Sources/XCLogParser/parser/BuildStep+Builder.swift
@@ -51,7 +51,8 @@ extension BuildStep {
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
                          clangTimeTraceFile: clangTimeTraceFile,
-                         linkerStatistics: linkerStatistics
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes
         )
     }
 
@@ -85,7 +86,8 @@ extension BuildStep {
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
                          clangTimeTraceFile: clangTimeTraceFile,
-                         linkerStatistics: linkerStatistics)
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes)
     }
 
     func with(signature newSignature: String) -> BuildStep {
@@ -118,7 +120,8 @@ extension BuildStep {
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
                          clangTimeTraceFile: clangTimeTraceFile,
-                         linkerStatistics: linkerStatistics)
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes)
     }
 
     func withFilteredNotices() -> BuildStep {
@@ -154,7 +157,8 @@ extension BuildStep {
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
                          clangTimeTraceFile: clangTimeTraceFile,
-                         linkerStatistics: linkerStatistics)
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes)
     }
 
     func with(subSteps newSubSteps: [BuildStep]) -> BuildStep {
@@ -187,7 +191,8 @@ extension BuildStep {
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
                          clangTimeTraceFile: clangTimeTraceFile,
-                         linkerStatistics: linkerStatistics)
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes)
     }
 
     func with(newCompilationEndTimestamp: Double,
@@ -221,7 +226,8 @@ extension BuildStep {
                          compilationEndTimestamp: newCompilationEndTimestamp,
                          compilationDuration: newCompilationDuration,
                          clangTimeTraceFile: clangTimeTraceFile,
-                         linkerStatistics: linkerStatistics)
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes)
     }
 
     func with(identifier newIdentifier: String) -> BuildStep {
@@ -254,7 +260,8 @@ extension BuildStep {
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
                          clangTimeTraceFile: clangTimeTraceFile,
-                         linkerStatistics: linkerStatistics)
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes)
     }
 
     func with(parentIdentifier newParentIdentifier: String) -> BuildStep {
@@ -287,7 +294,8 @@ extension BuildStep {
                          compilationEndTimestamp: compilationEndTimestamp,
                          compilationDuration: compilationDuration,
                          clangTimeTraceFile: clangTimeTraceFile,
-                         linkerStatistics: linkerStatistics)
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes)
     }
 
     private func filterNotices(_ notices: [Notice]?) -> [Notice]? {

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -281,7 +281,9 @@ public struct BuildStep: Encodable {
                 compilationEndTimestamp: Double,
                 compilationDuration: Double,
                 clangTimeTraceFile: String?,
-                linkerStatistics: LinkerStatistics?) {
+                linkerStatistics: LinkerStatistics?,
+                swiftTypeCheckTimes: [SwiftTypeCheck]?
+                ) {
         self.type = type
         self.machineName = machineName
         self.buildIdentifier = buildIdentifier
@@ -312,6 +314,7 @@ public struct BuildStep: Encodable {
         self.compilationDuration = compilationDuration
         self.clangTimeTraceFile = clangTimeTraceFile
         self.linkerStatistics = linkerStatistics
+        self.swiftTypeCheckTimes = swiftTypeCheckTimes
     }
 }
 

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -170,7 +170,8 @@ public final class ParserBuildSteps {
                                  compilationEndTimestamp: 0,
                                  compilationDuration: 0,
                                  clangTimeTraceFile: nil,
-                                 linkerStatistics: nil
+                                 linkerStatistics: nil,
+                                 swiftTypeCheckTimes: nil
                                  )
 
             step.subSteps = try logSection.subSections.map { subSection -> BuildStep in

--- a/Sources/XCLogParser/reporter/ChromeTracerReporter.swift
+++ b/Sources/XCLogParser/reporter/ChromeTracerReporter.swift
@@ -25,6 +25,8 @@ public struct ChromeTracerReporter: LogReporter {
 
     private let microSecondsPerSecond: Double = 1_000_000
 
+    public init() {}
+
     public func report(build: Any, output: ReporterOutput, rootOutput: String) throws {
         guard let steps = build as? BuildStep else {
             throw XCLogParserError.errorCreatingReport("Type not supported \(type(of: build))")

--- a/Sources/XCLogParser/reporter/FlatJsonReporter.swift
+++ b/Sources/XCLogParser/reporter/FlatJsonReporter.swift
@@ -21,6 +21,8 @@ import Foundation
 
 public struct FlatJsonReporter: LogReporter {
 
+    public init() {}
+
     public func report(build: Any, output: ReporterOutput, rootOutput: String) throws {
         guard let steps = build as? BuildStep else {
             throw XCLogParserError.errorCreatingReport("Type not supported \(type(of: build))")

--- a/Sources/XCLogParser/reporter/HtmlReporter.swift
+++ b/Sources/XCLogParser/reporter/HtmlReporter.swift
@@ -30,6 +30,8 @@ public struct HtmlReporter: LogReporter {
     /// Max number of slowest files to present in the main index file
     static let maxSlowestFiles = 20
 
+    public init() {}
+
     public func report(build: Any, output: ReporterOutput, rootOutput: String) throws {
         guard let steps = build as? BuildStep else {
             throw XCLogParserError.errorCreatingReport("Type not supported \(type(of: build))")

--- a/Sources/XCLogParser/reporter/IssuesReporter.swift
+++ b/Sources/XCLogParser/reporter/IssuesReporter.swift
@@ -26,6 +26,8 @@ struct Issues: Codable {
 
 public struct IssuesReporter: LogReporter {
 
+    public init() {}
+
     public func report(build: Any, output: ReporterOutput, rootOutput: String) throws {
         guard let steps = build as? BuildStep else {
             throw XCLogParserError.errorCreatingReport("Type not supported \(type(of: build))")

--- a/Sources/XCLogParser/reporter/JsonReporter.swift
+++ b/Sources/XCLogParser/reporter/JsonReporter.swift
@@ -21,6 +21,8 @@ import Foundation
 
 public struct JsonReporter: LogReporter {
 
+    public init() {}
+
     public func report(build: Any, output: ReporterOutput, rootOutput: String) throws {
         switch build {
         case let steps as BuildStep:

--- a/Sources/XCLogParser/reporter/Reporter.swift
+++ b/Sources/XCLogParser/reporter/Reporter.swift
@@ -27,7 +27,7 @@ public enum Reporter: String {
     case html
     case issues
 
-    func makeLogReporter() -> LogReporter {
+    public func makeLogReporter() -> LogReporter {
         switch self {
         case .chromeTracer:
             return ChromeTracerReporter()

--- a/Sources/XCLogParser/reporter/SummaryJsonReporter.swift
+++ b/Sources/XCLogParser/reporter/SummaryJsonReporter.swift
@@ -21,6 +21,8 @@ import Foundation
 
 public struct SummaryJsonReporter: LogReporter {
 
+    public init() {}
+
     public func report(build: Any, output: ReporterOutput, rootOutput: String) throws {
         guard let steps = build as? BuildStep else {
             throw XCLogParserError.errorCreatingReport("Type not supported \(type(of: build))")

--- a/Tests/XCLogParserTests/BuildStep+TestUtils.swift
+++ b/Tests/XCLogParserTests/BuildStep+TestUtils.swift
@@ -35,5 +35,6 @@ func makeFakeBuildStep(title: String,
                      compilationEndTimestamp: 0,
                      compilationDuration: 0,
                      clangTimeTraceFile: nil,
-                     linkerStatistics: nil)
+                     linkerStatistics: nil,
+                     swiftTypeCheckTimes: nil)
 }

--- a/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
+++ b/Tests/XCLogParserTests/ChromeTracerOutputTests.swift
@@ -82,7 +82,8 @@ class ChromeTracerOutputTests: XCTestCase {
                              compilationEndTimestamp: end.timeIntervalSince1970,
                              compilationDuration: 100 * 100,
                              clangTimeTraceFile: nil,
-                             linkerStatistics: nil
+                             linkerStatistics: nil,
+                             swiftTypeCheckTimes: nil
                              )
         return root
     }
@@ -119,7 +120,8 @@ class ChromeTracerOutputTests: XCTestCase {
                              compilationEndTimestamp: end.timeIntervalSince1970,
                              compilationDuration: 50 * 100,
                              clangTimeTraceFile: nil,
-                             linkerStatistics: nil
+                             linkerStatistics: nil,
+                             swiftTypeCheckTimes: nil
                              )
 
         let end2 = end.addingTimeInterval(50 * 100)
@@ -152,7 +154,8 @@ class ChromeTracerOutputTests: XCTestCase {
                                 compilationEndTimestamp: end2.timeIntervalSince1970,
                                 compilationDuration: 50 * 100,
                                 clangTimeTraceFile: nil,
-                                linkerStatistics: nil
+                                linkerStatistics: nil,
+                                swiftTypeCheckTimes: nil
                                 )
         return [target1, target2]
 

--- a/Tests/XCLogParserTests/IssuesReporterTests.swift
+++ b/Tests/XCLogParserTests/IssuesReporterTests.swift
@@ -79,7 +79,8 @@ class IssuesReporterTests: XCTestCase {
                              compilationEndTimestamp: end.timeIntervalSince1970,
                              compilationDuration: 100 * 100,
                              clangTimeTraceFile: nil,
-                             linkerStatistics: nil
+                             linkerStatistics: nil,
+                             swiftTypeCheckTimes: nil
         )
         return root
     }
@@ -130,7 +131,8 @@ class IssuesReporterTests: XCTestCase {
                              compilationEndTimestamp: end.timeIntervalSince1970,
                              compilationDuration: 100 * 100,
                              clangTimeTraceFile: nil,
-                             linkerStatistics: nil
+                             linkerStatistics: nil,
+                             swiftTypeCheckTimes: nil
         )
         return root
     }
@@ -181,7 +183,8 @@ class IssuesReporterTests: XCTestCase {
                          compilationEndTimestamp: end.timeIntervalSince1970,
                          compilationDuration: 100 * 100,
                          clangTimeTraceFile: nil,
-                         linkerStatistics: nil
+                         linkerStatistics: nil,
+                         swiftTypeCheckTimes: nil
         )
     }
 }


### PR DESCRIPTION
- Fixes issue https://github.com/spotify/XCLogParser/issues/132
- Makes the Reporter's initializers public, as suggested in https://github.com/spotify/XCLogParser/issues/129
- Bumps dependency to fix the build in Xcode 12.5