### PR TITLE
Fix XCLogParser function/typechecking recognition for modern Xcode versions

### DIFF
--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -96,7 +96,7 @@ public enum DetailStepType: String, Encodable {
         switch signature {
         case Prefix("CompileC "):
             return .cCompilation
-        case Prefix("CompileSwift "):
+        case Prefix("SwiftCompile "):
             return .swiftCompilation
         case Prefix("Ld "):
             return .linker

--- a/Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift
+++ b/Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift
@@ -87,7 +87,7 @@ extension IDEActivityLogSection {
     public func getSwiftIndividualSteps(buildStep: BuildStep,
                                         parentCommandDetailDesc: String,
                                         currentIndex: inout Int) -> [BuildStep]? {
-        let pattern = #"^CompileSwift\s\w+\s\w+\s.+\.swift\s"#
+        let pattern = #"^SwiftCompile\s\w+\s\w+\s.+\.swift\s"#
         guard commandDetailDesc.range(of: pattern, options: .regularExpression) == nil else {
             return nil
         }

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -75,7 +75,7 @@ public final class ParserBuildSteps {
     }()
 
     lazy var swiftcArchRegexp: NSRegularExpression? = {
-        let pattern = "^CompileSwift normal (\\w*) "
+        let pattern = "^SwiftCompile normal (\\w*) "
         return NSRegularExpression.fromPattern(pattern)
     }()
 

--- a/Sources/XCLogParser/parser/SwiftFunctionTime.swift
+++ b/Sources/XCLogParser/parser/SwiftFunctionTime.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 /// Represents the time it took to the Swift Compiler to compile a function
-public struct SwiftFunctionTime: Encodable {
+public struct SwiftFunctionTime: Encodable, Hashable {
     /// URL of the file where the function is
     public let file: String
 

--- a/Sources/XCLogParser/parser/SwiftTypeCheck.swift
+++ b/Sources/XCLogParser/parser/SwiftTypeCheck.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 /// Represents the time it took to the Swift Compiler to type check an expression
-public struct SwiftTypeCheck: Encodable {
+public struct SwiftTypeCheck: Encodable, Hashable {
 
     /// URL of the file where the function is
     public let file: String

--- a/Tests/XCLogParserTests/ParserTests.swift
+++ b/Tests/XCLogParserTests/ParserTests.swift
@@ -541,8 +541,8 @@ CompileSwift normal x86_64 (in target 'Alamofire' from project 'Pods')
     lazy var fakeSwiftCompilation: IDEActivityLogSection = {
         return IDEActivityLogSection(sectionType: 1,
                                      domainType: "",
-                                     title: "CompileSwift",
-                                     signature: "CompileSwift normal x86_64",
+                                     title: "SwiftCompile",
+                                     signature: "SwiftCompile normal x86_64",
                                      timeStartedRecording: 1.0,
                                      timeStoppedRecording: 2.0,
                                      subSections: [],


### PR DESCRIPTION
Closes https://github.com/MobileNativeFoundation/XCLogParser/issues/190

Since `xclogparser` was last updated, there have been various changes in the way that Xcode builds are handled:

1. The prefix for swift compilation steps is now `SwiftCompile`, not `CompileSwift`. This changes build step recognition in `BuildStep.swift`, but also changes the various regular expressions used for identifying these steps. 
2. Standard swift compilation steps are now _batch compilation steps_ – similar in behavior to the `swiftAggregatedCompilation` step that is already defined. You can read more about that here: https://github.com/swiftlang/swift/blob/main/docs/CompilerPerformance.md#compilation-modes 
3. As an addendum to (2): Since these batch steps are asynchronous and parallelized, there are situations where substep function and type check times may be duplicated. As such, we ensure we're de-duplicating them by passing them through a `Set`. 

**In short:** this allows the type checking and function time data to appear in the outputs without causing memory explosions or runtime explosions. 

Things to note:

1. Since these compilation steps are all batch steps… while this does cause the `Slowest Swift Files` to appear in the HTML reporter, this isn't really even a valid metric anymore since it's the measurement of _n_ file compilations. `XYZ.swift` didn't take 20 seconds to compile – rather, it and its batch of files took that time. **We should probably fully remove this section from the HTML output**, unless the compilation mode is setup for single files. For now, I'm leaving it as is.
2. **This represents a hard version upgrade**. It will not work for older versions of Xcode that don't use this build system. 
3. I haven't tested single file compilation mode. 
4. Module time compilation isn't reporting any differently than it was previously, however, I always found this to be a somewhat flawed metric: it's showing the aggregate time of the module _and its dependencies_. If we have a 5 line module that depends on a gigantic module, we often run into the situation where the small module reports a compilation time ~1s larger than its dependent module. 
____

<details><summary>🤖  Copilot Generated PR Description and Outline</summary>
<p>


This pull request includes several changes to improve the parsing and reporting of Swift compilation steps in the `XCLogParser` project. The changes focus on updating patterns for Swift compilation, enhancing data structures for performance, and refining the reporting logic.

Changes to update `CompileSwift` prefix:

* [`Sources/XCLogParser/parser/BuildStep.swift`](diffhunk://#diff-3372f9b6bbcb9136866c94acb5e5cea8158f9582cda7c25094bed8da7434f4d2L99-R99): Updated the prefix from `CompileSwift` to `SwiftCompile` in the `DetailStepType` enum.
* [`Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift`](diffhunk://#diff-88341bc26265a05c61d1cd2763c8381362d9298c1d6c5643d0dda9a47018bf8bL90-R90): Updated the regular expression pattern to match `SwiftCompile` instead of `CompileSwift`.
* [`Sources/XCLogParser/parser/ParserBuildSteps.swift`](diffhunk://#diff-c6d727600c528a9c21727d4966536a2d0de10db104c39e773f802ab4c6f9e107L78-R78): Changed the pattern in `swiftcArchRegexp` to match `SwiftCompile` instead of `CompileSwift`.

Changes to improve handling of Swift function and type check times:

* [`Sources/XCLogParser/reporter/HtmlReporter.swift`](diffhunk://#diff-b4255f73b13bccfa56ff17aa88761152d442e9dfaf3b1b99bb7b478c44aacb73L206-L211): Replaced arrays with sets for `swiftFunctionTimes` and `swiftTypeCheckTimes` to avoid duplicates and ensure unique entries. [[1]](diffhunk://#diff-b4255f73b13bccfa56ff17aa88761152d442e9dfaf3b1b99bb7b478c44aacb73L206-L211) [[2]](diffhunk://#diff-b4255f73b13bccfa56ff17aa88761152d442e9dfaf3b1b99bb7b478c44aacb73L223-R238)

Conformance to `Hashable` protocol:

* [`Sources/XCLogParser/parser/SwiftFunctionTime.swift`](diffhunk://#diff-6bb015e828b3950f41ceee94940515402191acb0386052764293b21b71179bacL23-R23): Made `SwiftFunctionTime` conform to the `Hashable` protocol.
* [`Sources/XCLogParser/parser/SwiftTypeCheck.swift`](diffhunk://#diff-31e213cb4579010d4c52ac94952797f4b0b16327e1480feb4788012fce558ba6L23-R23): Made `SwiftTypeCheck` conform to the `Hashable` protocol.

</p>
</details> 


_____

### Screenshots and Outputs

#### HTML Screenshot

<img width="1656" alt="Screenshot 2025-03-13 at 10 28 22 AM" src="https://github.com/user-attachments/assets/12937612-643e-423b-b30b-a7f7fcf18a1d" />

#### FlatJSON Output (Redacting app name)

Excerpt 1:

```
[
  {
    "type" : "main",
    "fetchedFromCache" : false,
    "errorCount" : 0,
    "compilationEndTimestamp" : 1741873280.071251,
    "errors" : [

    ],
    "schema" : "<REDACTED>",
    "compilationDuration" : 451.705482006073,
    "endDate" : "2025-03-13T13:41:39.543000Z",
    "detailStepType" : "none",
    "startDate" : "2025-03-13T13:33:48.366000Z",
    "parentIdentifier" : "",
    "buildIdentifier" : "Hesham’s MacBook Pro_C73D272C-AA17-42E3-99B2-77AC929317F4",
    "warningCount" : 143,
    "notes" : [
      {
        "title" : "Run script build phase 'Set Bundle Version' will be run during every build because the option to run the script phase \"Based on dependency analysis\" is unchecked.",
        "startingLineNumber" : 0,
        "type" : "note",
        "severity" : 0,
        "characterRangeEnd" : 0,
        "detail" : "note: Run script build phase 'Set Bundle Version' will be run during every build because the option to run the script phase \"Based on dependency analysis\" is unchecked. (in target 'PullsWidget' from project 'REDACTED')\rnote: Run script build phase 'Set Bundle Version' will be run during every build because the option to run the script phase \"Based on dependency analysis\" is unchecked. (in target 'NotificationService' from project 'REDACTED')\rnote: Run script build phase 'Set Bundle Version' will be run during every build because the option to run the script phase \"Based on dependency analysis\" is unchecked. (in target 'IntentsService' from project 'REDACTED')\rnote: Run script build phase 'SwiftLint' will be run during every build because the option to run the script phase \"Based on dependency analysis\" is unchecked. (in target 'REDACTED' from project 'REDACTED')\rnote: Run script build phase 'Crashlytics' will be run during every build because the option to run the script phase \"Based on dependency analysis\" is unchecked. (in target 'REDACTED' from project 'REDACTED')\rnote: Run script build phase 'Set Bundle Version' will be run during every build because the option to run the script phase \"Based on dependency analysis\" is unchecked. (in target 'REDACTED' from project 'REDACTED')\r\/Users\/zer0\/Developer\/REDACTED\/mobile-ios\/.build\/Xcode\/DerivedData\/SourcePackages\/checkouts\/firebase-ios-sdk\/Package.swift: warning: DEFINES_MODULE was set, but no umbrella header could be found to generate the module map (in target 'Firebase' from project 'Firebase')\rnote: Run script build phase 'Set Bundle Version' will be run during every build because the option to run the script phase \"Based on dependency analysis\" is unchecked. (in target 'ContributionGraphWidget' from project 'REDACTED')",
        "startingColumnNumber" : 0,
        "endingColumnNumber" : 0,
```

Excerpt 2:

```
    "documentURL" : "file:\/\/\/Users\/zer0\/Developer\/REDACTED\/mobile-ios\/Modules\/_REDACTEDMarkdown_Routes\/Sources\/UIResponder+WebViewPreviewable.swift",
    "endDate" : "2025-03-13T13:40:00.822000Z",
    "swiftFunctionTimes" : [
      {
        "file" : "file:\/\/\/Users\/zer0\/Developer\/REDACTED\/mobile-ios\/Modules\/_REDACTEDMarkdown_Routes\/Sources\/UIResponder+WebViewPreviewable.swift",
        "startingColumn" : 17,
        "signature" : "instance method _REDACTEDbMarkdown_Routes.(file).UIResponder extension.onPreview(url:)@\/Users\/zer0\/Developer\/REDACTED\/mobile-ios\/Modules\/_REDACTEDMarkdown_Routes\/Sources\/UIResponder+WebViewPreviewable.swift:7:17",
        "durationMS" : 0.73,
        "startingLine" : 7,
        "occurrences" : 1
      },
      {
        "startingColumn" : 17,
        "signature" : "instance method _REDACTEDMarkdown_Routes.(file).UIResponder extension.presentPreview(url:)@\/Users\/zer0\/Developer\/REDACTED\/mobile-ios\/Modules\/_REDACTEDMarkdown_Routes\/Sources\/UIResponder+WebViewPreviewable.swift:11:17",
        "durationMS" : 0.37,
        "occurrences" : 1,
        "startingLine" : 11,
        "file" : "file:\/\/\/Users\/zer0\/Developer\/REDACTED\/mobile-ios\/Modules\/_REDACTEDMarkdown_Routes\/Sources\/UIResponder+WebViewPreviewable.swift"
      }
    ]
  },
```