### PR TITLE
fix: ignore stale substep timestamps when computing target compilation duration

### DIFF
--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -373,8 +373,16 @@ public final class ParserBuildSteps {
 
     private func addCompilationTimesToTarget(_ target: BuildStep) -> BuildStep {
 
+        // For incremental builds, Xcode reuses substep entries from prior build sessions for files
+        // that didn't need recompilation. Those substeps keep their original (older) timestamps and
+        // are not flagged `wasFetchedFromCache`. Filtering them out by requiring the substep to
+        // have ended at or after the target started avoids producing a negative compilationDuration.
         let lastCompilationStep = target.subSteps
-            .filter { $0.isCompilationStep() && $0.fetchedFromCache == false }
+            .filter {
+                $0.isCompilationStep()
+                    && $0.fetchedFromCache == false
+                    && $0.compilationEndTimestamp >= target.startTimestamp
+            }
             .max { $0.compilationEndTimestamp < $1.compilationEndTimestamp }
         guard let lastStep = lastCompilationStep else {
             return target.with(newCompilationEndTimestamp: target.startTimestamp, andCompilationDuration: 0.0)
@@ -385,7 +393,11 @@ public final class ParserBuildSteps {
 
     private func addCompilationTimesToApp(_ app: BuildStep) -> BuildStep {
         let lastCompilationStep = app.subSteps
-            .filter { $0.compilationDuration > 0 && $0.fetchedFromCache == false }
+            .filter {
+                $0.compilationDuration > 0
+                    && $0.fetchedFromCache == false
+                    && $0.compilationEndTimestamp >= app.startTimestamp
+            }
             .max { $0.compilationEndTimestamp < $1.compilationEndTimestamp }
         guard let lastStep = lastCompilationStep else {
             return app.with(newCompilationEndTimestamp: app.startTimestamp,

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -373,16 +373,9 @@ public final class ParserBuildSteps {
 
     private func addCompilationTimesToTarget(_ target: BuildStep) -> BuildStep {
 
-        // For incremental builds, Xcode reuses substep entries from prior build sessions for files
-        // that didn't need recompilation. Those substeps keep their original (older) timestamps and
-        // are not flagged `wasFetchedFromCache`. Filtering them out by requiring the substep to
-        // have ended at or after the target started avoids producing a negative compilationDuration.
         let lastCompilationStep = target.subSteps
-            .filter {
-                $0.isCompilationStep()
-                    && $0.fetchedFromCache == false
-                    && $0.compilationEndTimestamp >= target.startTimestamp
-            }
+            .filter { $0.isCompilationStep() && $0.fetchedFromCache == false &&
+                $0.compilationEndTimestamp >= target.startTimestamp }
             .max { $0.compilationEndTimestamp < $1.compilationEndTimestamp }
         guard let lastStep = lastCompilationStep else {
             return target.with(newCompilationEndTimestamp: target.startTimestamp, andCompilationDuration: 0.0)
@@ -393,11 +386,8 @@ public final class ParserBuildSteps {
 
     private func addCompilationTimesToApp(_ app: BuildStep) -> BuildStep {
         let lastCompilationStep = app.subSteps
-            .filter {
-                $0.compilationDuration > 0
-                    && $0.fetchedFromCache == false
-                    && $0.compilationEndTimestamp >= app.startTimestamp
-            }
+            .filter { $0.compilationDuration > 0 && $0.fetchedFromCache == false &&
+                $0.compilationEndTimestamp >= app.startTimestamp }
             .max { $0.compilationEndTimestamp < $1.compilationEndTimestamp }
         guard let lastStep = lastCompilationStep else {
             return app.with(newCompilationEndTimestamp: app.startTimestamp,

--- a/Tests/XCLogParserTests/ParserTests.swift
+++ b/Tests/XCLogParserTests/ParserTests.swift
@@ -346,6 +346,31 @@ note: use 'updatedDoSomething' instead\r doSomething()\r        ^~~~~~~~~~~\r   
         XCTAssertEqual(expectedCompilationDuration, targetStep.compilationDuration)
     }
 
+    func testParseTargetCompilationTimesIgnoresStaleSubsteps() {
+        // For incremental builds, Xcode reuses substep entries from previous build sessions for
+        // files that didn't need recompilation. Those substeps keep their original (older)
+        // timestamps and are not flagged `wasFetchedFromCache`. The target's compilationDuration
+        // must remain non-negative; substeps that ended before the target started belong to a
+        // prior session and should be ignored.
+        let now = Date().timeIntervalSince1970
+        let staleCompileEnd = now - 1000
+        let staleStep = makeFakeBuildStep(title: "Stale Compile",
+                                          type: .detail,
+                                          detailStepType: .cCompilation,
+                                          startTimestamp: now - 1010,
+                                          fetchedFromCache: false)
+            .with(newCompilationEndTimestamp: staleCompileEnd, andCompilationDuration: 10)
+        var targetStep = makeFakeBuildStep(title: "Build Target",
+                                           type: .target,
+                                           detailStepType: .none,
+                                           startTimestamp: now,
+                                           fetchedFromCache: false).with(subSteps: [staleStep])
+
+        targetStep = parser.addCompilationTimes(step: targetStep)
+        XCTAssertEqual(targetStep.startTimestamp, targetStep.compilationEndTimestamp)
+        XCTAssertEqual(0.0, targetStep.compilationDuration)
+    }
+
     func testParseAppCompilationTimes() {
         let expectedCompilationDuration = 50.0
         let now = Date().timeIntervalSince1970


### PR DESCRIPTION
## Summary

`addCompilationTimesToTarget` (and `addCompilationTimesToApp`) currently subtract `target.startTimestamp` from the latest substep's `compilationEndTimestamp`. For incremental Xcode builds this can produce a **negative** `compilationDuration` because Xcode reuses substep entries from prior build sessions for files that didn't need recompilation. Those substeps keep their original (older) timestamps and are not flagged `wasFetchedFromCache`, so the existing filter doesn't exclude them, and the chosen "last compile substep" can have ended long before the target started.

This PR filters those stale substeps out by also requiring `compilationEndTimestamp >= parent.startTimestamp`.

## Concrete example

A real `.xcactivitylog` from an incremental build (404 targets, ~52s wall clock, only one target's sources had changed):

| | Before | After |
|---|---|---|
| Targets with negative `compilationDuration` | 364 / 404 | 0 / 404 |
| Targets with zero | 39 | 403 |
| Targets with positive | 1 (0.41s) | 1 (0.41s) |

The single target with positive duration was the only one with source changes requiring real compilation; the rest correctly report 0. Without the fix, those 403 targets each report values around `-1118s`, which downstream consumers (e.g. systems storing `compilationDuration` as an unsigned integer) wrap into nonsensical huge numbers.

## Test plan

- [x] Added `testParseTargetCompilationTimesIgnoresStaleSubsteps` covering a target whose only substep ended before the target started; expects `compilationDuration == 0` and `compilationEndTimestamp == startTimestamp`.
- [x] Existing `testParseTargetCompilationTimes`, `testParseAppCompilationTimes`, and `testParseAppNoopCompilationTimes` still pass.
- [x] Re-parsed an affected real-world `.xcactivitylog` and confirmed all `compilationDuration` values are non-negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)