### PR TITLE
Version 0.2.47

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.46"
+    public static let current = "0.2.47"
 
 }


### PR DESCRIPTION
## Summary
- Bump version to 0.2.47

Includes since 0.2.46:
- #249 fix: ignore stale substep timestamps when computing target compilation duration
- #244 fix: Xcode 26.4 BuildOperationMetrics format
- #248 ci: fix Xcode version in release workflow for macos-26 runner