### PR TITLE
fix: tolerate missing cache metrics in Xcode logs

### DIFF
--- a/Sources/XCLogParser/activityparser/IDEActivityModel.swift
+++ b/Sources/XCLogParser/activityparser/IDEActivityModel.swift
@@ -792,10 +792,10 @@ public class IDEActivityLogSectionAttachment: Encodable {
             } else {
                 let legacy = try decoder.decode(LegacyCacheMetrics.self, from: jsonData)
                 self.counters = [
-                    "clangCacheHits": legacy.clangCacheHits,
-                    "clangCacheMisses": legacy.clangCacheMisses,
-                    "swiftCacheHits": legacy.swiftCacheHits,
-                    "swiftCacheMisses": legacy.swiftCacheMisses,
+                    "clangCacheHits": legacy.clangCacheHits ?? 0,
+                    "clangCacheMisses": legacy.clangCacheMisses ?? 0,
+                    "swiftCacheHits": legacy.swiftCacheHits ?? 0,
+                    "swiftCacheMisses": legacy.swiftCacheMisses ?? 0,
                 ]
                 self.taskCounters = [:]
             }
@@ -805,8 +805,8 @@ public class IDEActivityLogSectionAttachment: Encodable {
 
 /// Legacy Xcode 15.3 - Xcode 26.3 BuildOperationMetrics format, used only for deserialization.
 private struct LegacyCacheMetrics: Decodable {
-    let clangCacheHits: Int
-    let clangCacheMisses: Int
-    let swiftCacheHits: Int
-    let swiftCacheMisses: Int
+    let clangCacheHits: Int?
+    let clangCacheMisses: Int?
+    let swiftCacheHits: Int?
+    let swiftCacheMisses: Int?
 }


### PR DESCRIPTION
## Summary

Fixes decoding failures for newer Xcode activity logs where cache metric fields such as `clangCacheHits` may be omitted.

## Changes

* Makes legacy cache metric fields optional during decoding.
* Uses default values (`0`) when fields are missing.
* Keeps existing behavior unchanged when fields are present.

## Problem

Some newer Xcode log formats can omit these cache metrics, causing decoding errors such as:

`keyNotFound("clangCacheHits")`

## Result

Improves compatibility with newer Xcode-generated logs while preserving support for older formats.
