### PR TITLE
Fix Xcode 27 activity log section parsing

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -105,7 +105,14 @@ public class ActivityParser {
         let timeStartedRecording = try parseAsDouble(token: iterator.next())
         let timeStoppedRecording = try parseAsDouble(token: iterator.next())
         let subSections = try parseIDEActivityLogSections(iterator: &iterator)
-        let text = try parseAsString(token: iterator.next())
+        var textToken = iterator.next()
+        // On Xcode 27.0+, an integer that most likely represents the ended status
+        // appears before text. XCLogParser does not currently model it because
+        // there is no use case for exposing it.
+        if case .some(.int) = textToken {
+            textToken = iterator.next()
+        }
+        let text = try parseAsString(token: textToken)
         let messages = try parseMessages(iterator: &iterator)
         let wasCancelled = try parseBoolean(token: iterator.next())
         let isQuiet = try parseBoolean(token: iterator.next())

--- a/Tests/XCLogParserTests/ActivityParserTests.swift
+++ b/Tests/XCLogParserTests/ActivityParserTests.swift
@@ -214,6 +214,37 @@ class ActivityParserTests: XCTestCase {
         return startTokens + logMessageTokens + endTokens
     }()
 
+    // Xcode 27.0 format: ended status likely appears before text
+    lazy var IDEActivityLogSectionTokensXcode270: [Token] = {
+        let startTokens = [Token.int(2),
+                           Token.string("com.apple.dt.IDE.BuildLogSection"),
+                           Token.string("Prepare build"),
+                           Token.string("Prepare build"),
+                           Token.double(575479851.278759),
+                           Token.double(575479851.778325),
+                           Token.null,
+                           Token.int(0),
+                           Token.string("note: Using legacy build system"),
+                           Token.list(1),
+                           Token.className("IDEActivityLogMessage"),
+                           Token.classNameRef("IDEActivityLogMessage"),
+        ]
+        let logMessageTokens = IDEActivityLogMessageTokens
+        let endTokens = [Token.int(1),
+                         Token.int(0),
+                         Token.int(1),
+                         Token.int(42),
+                         Token.string("subtitle"),
+                         Token.null,
+                         Token.string("commandDetailDesc"),
+                         Token.string("501796C4-6BE4-4F80-9F9D-3269617ECC17"),
+                         Token.string("localizedResultString"),
+                         Token.string("xcbuildSignature"),
+                         Token.list(0),  // attachments
+        ]
+        return startTokens + logMessageTokens + endTokens
+    }()
+
     let IDEConsoleItemTokens: [Token] = [
         Token.className("IDEConsoleItem"),
         Token.classNameRef("IDEConsoleItem"),
@@ -516,6 +547,34 @@ class ActivityParserTests: XCTestCase {
         } else {
             XCTFail("Expected BuildOperationMetrics")
         }
+        XCTAssertEqual(42, logSection.unknown)
+    }
+
+    func testParseIDEActivityLogSectionXcode270() throws {
+        parser.logVersion = 13
+        let tokens = IDEActivityLogSectionTokensXcode270
+        var iterator = tokens.makeIterator()
+        let logSection = try parser.parseIDEActivityLogSection(iterator: &iterator)
+        XCTAssertEqual(2, logSection.sectionType)
+        XCTAssertEqual("com.apple.dt.IDE.BuildLogSection", logSection.domainType)
+        XCTAssertEqual("Prepare build", logSection.title)
+        XCTAssertEqual("Prepare build", logSection.signature)
+        XCTAssertEqual(575479851.278759, logSection.timeStartedRecording)
+        XCTAssertEqual(575479851.778325, logSection.timeStoppedRecording)
+        XCTAssertEqual(0, logSection.subSections.count)
+        XCTAssertEqual("note: Using legacy build system", logSection.text)
+        XCTAssertEqual(1, logSection.messages.count)
+        XCTAssertTrue(logSection.wasCancelled)
+        XCTAssertFalse(logSection.isQuiet)
+        XCTAssertTrue(logSection.wasFetchedFromCache)
+        XCTAssertEqual("subtitle", logSection.subtitle)
+        XCTAssertEqual("", logSection.location.documentURLString)
+        XCTAssertEqual(0, logSection.location.timestamp)
+        XCTAssertEqual("commandDetailDesc", logSection.commandDetailDesc)
+        XCTAssertEqual("501796C4-6BE4-4F80-9F9D-3269617ECC17", logSection.uniqueIdentifier)
+        XCTAssertEqual("localizedResultString", logSection.localizedResultString)
+        XCTAssertEqual("xcbuildSignature", logSection.xcbuildSignature)
+        XCTAssertEqual(0, logSection.attachments.count)
         XCTAssertEqual(42, logSection.unknown)
     }
 

--- a/Tests/XCLogParserTests/XCTestManifests.swift
+++ b/Tests/XCLogParserTests/XCTestManifests.swift
@@ -13,6 +13,7 @@ extension ActivityParserTests {
         ("testParseIDEActivityLogAnalyzerResultMessage", testParseIDEActivityLogAnalyzerResultMessage),
         ("testParseIDEActivityLogMessage", testParseIDEActivityLogMessage),
         ("testParseIDEActivityLogSection", testParseIDEActivityLogSection),
+        ("testParseIDEActivityLogSectionXcode270", testParseIDEActivityLogSectionXcode270),
         ("testParseXcode3ProjectLocation", testParseXcode3ProjectLocation),
     ]
 }


### PR DESCRIPTION
## What changed

- Teach `ActivityParser` to tolerate the extra integer that Xcode 27.0 serializes between an activity log section's `subSections` array and `text` field.
- Add a token-level regression test that models the Xcode 27.0 section layout.
- Register the new test in the Linux XCTest manifest.

## Why

Xcode 27.0 `.xcactivitylog` files can fail to parse with:

```text
Unexpected token parsing String: [type: int, value: 0]
```

The root cause is a serialized format change: section records may include an unknown integer immediately before the text token. Older parser versions read that integer as the text field and fail before any higher-level build parsing can continue.

## Impact

Consumers such as Tuist's build analytics processor can parse Xcode 27 build logs instead of rejecting the build payload.

## Validation

- `swift test --filter ActivityParserTests`
- `swift test`
- `.build/debug/xclogparser dump --file '/Users/marekfort/Downloads/xcactivitylog 2/A0007701-F087-4D49-9DB4-DE7A21EB2229.xcactivitylog' --output /private/tmp/xclogparser-xcode27.json`