### PR TITLE
Version 0.2.48

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.47"
+    public static let current = "0.2.48"
 
 }


### PR DESCRIPTION
## What changed

- Bump XCLogParser's reported version to 0.2.48.

## Why

This prepares the patch release that includes the Xcode 27 activity log section parsing fix from #252.

## Validation

- rake test