### PR TITLE
Version 0.2.49

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.48"
+    public static let current = "0.2.49"
 
 }


### PR DESCRIPTION
## What changed

Bump XCLogParser's reported version from `0.2.48` to `0.2.49`.

## Why

This prepares a patch release that includes the SLF byte-length string parsing and embedded-NUL log loading fixes merged in #254. Keeping `Version.current` aligned with the release tag ensures the built CLI reports the same version as the published artifacts.

## Root cause

The parser fix included in this release addresses activity logs whose SLF strings are measured in UTF-8 bytes and whose decoded payload can contain embedded NUL bytes. The previous parser could advance through those payloads incorrectly, which caused valid activity logs to fail parsing.

## Developer impact

Consumers of the release binaries can pick up the parser fix by updating to `v0.2.49`.

## Validation

- `rake test`
